### PR TITLE
Not show TRANSIENT_LOCAL for best_effort [5553]

### DIFF
--- a/include/eprosimashapesdemo/qt/publishdialog.h
+++ b/include/eprosimashapesdemo/qt/publishdialog.h
@@ -36,7 +36,7 @@ public:
 private slots:
 
     void on_button_OkCancel_accepted();
-
+    void on_checkBox_reliable_clicked();
     void on_comboBox_ownership_currentIndexChanged(int index);
 
 private:

--- a/src/qt/publishdialog.cpp
+++ b/src/qt/publishdialog.cpp
@@ -35,8 +35,6 @@ PublishDialog::~PublishDialog()
     delete ui;
 }
 
-
-
 void PublishDialog::on_button_OkCancel_accepted()
 {
     ShapePublisher* SP = new ShapePublisher(this->mp_sd->getParticipant());
@@ -130,6 +128,21 @@ void PublishDialog::on_button_OkCancel_accepted()
 
 
 
+}
+
+void PublishDialog::on_checkBox_reliable_clicked()
+{
+    if (ui->checkBox_reliable->isChecked())
+    {
+        // Add TRANSIENT_LOCAL item
+        ui->comboBox_durability->addItem("TRANSIENT_LOCAL");
+        ui->comboBox_durability->setCurrentIndex(1);
+    }
+    else
+    {
+        // Remove TRANSIENT_LOCAL item
+        ui->comboBox_durability->removeItem(1);
+    }
 }
 
 void PublishDialog::setShapeAttributes(ShapePublisher* SP)


### PR DESCRIPTION
TRANSIENT_LOCAL was shown even when reliability was set to bet-effort, now it's only shown for reliable.