### PR TITLE
[20034] Enable-Disable monitor service on shapes demo

### DIFF
--- a/forms/participantdialog.ui
+++ b/forms/participantdialog.ui
@@ -161,14 +161,21 @@
      </property>
     </widget>
    </item>
-   <item row="21" column="0">
+   <item row="21" column="1">
+    <widget class="QCheckBox" name="monitorServiceCheckBox">
+     <property name="text">
+      <string>Active Monitor Service</string>
+     </property>
+    </widget>
+   </item>
+   <item row="22" column="0">
     <widget class="Line" name="line_5">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="22" column="0">
+   <item row="23" column="0">
     <widget class="QLabel" name="label_12">
      <property name="font">
       <font>
@@ -181,7 +188,7 @@
      </property>
     </widget>
    </item>
-   <item row="23" column="1">
+   <item row="24" column="1">
     <widget class="QCheckBox" name="rosTopicCheckBox">
      <property name="text">
       <string>Use ROS 2 Topics</string>

--- a/include/eprosimashapesdemo/qt/participantdialog.h
+++ b/include/eprosimashapesdemo/qt/participantdialog.h
@@ -76,6 +76,9 @@ private slots:
 
     void tcp_enable_buttons();
 
+    void on_monitorServiceCheckBox_stateChanged(
+            int arg1);
+
 private:
 
     ShapesDemoOptions* m_options;

--- a/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
+++ b/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
@@ -47,7 +47,7 @@ std::string qos_policy_id_to_string(
         QosPolicyId_t policy_id);
 
 #ifdef ENABLE_ROS_COMPONENTS
-    bool detect_ros_2_installation();
+bool detect_ros_2_installation();
 #endif // ifdef ENABLE_ROS_COMPONENTS
 
 /**
@@ -64,6 +64,7 @@ public:
     bool m_shm_transport;
     bool m_statistics;
     bool m_ros2_topic;
+    bool m_monitor_service;
     QString m_tcp_type;
     uint16_t m_listenPort;
     uint16_t m_serverPort;
@@ -86,11 +87,12 @@ public:
         m_movementSpeed = 7;
         m_domainId = 0;
         m_tcp_type = QString("TCP LAN Server");
+        m_monitor_service = false;
 #ifdef ENABLE_ROS_COMPONENTS
         m_ros2_topic = detect_ros_2_installation();
 #else
         m_ros2_topic = false;
-#endif
+#endif // ifdef ENABLE_ROS_COMPONENTS
     }
 
     bool tcp_lan()

--- a/src/qt/participantdialog.cpp
+++ b/src/qt/participantdialog.cpp
@@ -50,6 +50,7 @@ ParticipantDialog::ParticipantDialog(
     // Statistics Button
     // Show if it is checked or not
     this->ui->statisticsCheckBox->setChecked(m_options->m_statistics);
+    this->ui->monitorServiceCheckBox->setChecked(m_options->m_monitor_service);
 #ifdef ENABLE_ROS_COMPONENTS
     this->ui->rosTopicCheckBox->setChecked(m_options->m_ros2_topic);
 #else
@@ -84,6 +85,7 @@ void ParticipantDialog::setEnableState()
     this->ui->pushButton_start->setEnabled(mb_started);
     this->ui->spin_domainId->setEnabled(mb_started);
     this->ui->statisticsCheckBox->setEnabled(mb_started);
+    this->ui->monitorServiceCheckBox->setEnabled(mb_started);
 #ifdef ENABLE_ROS_COMPONENTS
     if (!detect_ros_2_installation())
     {
@@ -247,4 +249,11 @@ void ParticipantDialog::on_TCPcomboBox_currentTextChanged(
     mp_sd->setOptions(*m_options);
 
     tcp_enable_buttons();
+}
+
+void ParticipantDialog::on_monitorServiceCheckBox_stateChanged(
+        int arg1)
+{
+    m_options->m_monitor_service = arg1;
+    mp_sd->setOptions(*m_options);
 }

--- a/src/shapesdemo/ShapesDemo.cpp
+++ b/src/shapesdemo/ShapesDemo.cpp
@@ -115,6 +115,12 @@ bool ShapesDemo::init()
         qos.properties().properties().emplace_back("fastdds.application.id", "SHAPES_DEMO", true);
         qos.properties().properties().emplace_back("fastdds.application.metadata", "", true);
 
+        if (m_options.m_monitor_service)
+        {
+            qos.properties().properties().emplace_back(
+                "fastdds.enable_monitor_service",
+                "true");
+        }
         // Intraprocess
         LibrarySettingsAttributes library_settings;
         library_settings.intraprocess_delivery = m_options.m_intraprocess_transport ?
@@ -609,4 +615,5 @@ bool detect_ros_2_installation()
 
     return false;
 }
+
 #endif // ifdef ENABLE_ROS_COMPONENTS


### PR DESCRIPTION
The feature adds a checkbox in shapes demo 'Participant Configuration' windows to enable/disable monitor service. Documentation: https://github.com/eProsima/Shapes-Demo-Docs/pull/72
Merge after:
- https://github.com/eProsima/Fast-DDS/pull/3894