### PR TITLE
[20106] Add checkbox to configure data representation

### DIFF
--- a/forms/publishdialog.ui
+++ b/forms/publishdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>481</width>
-    <height>680</height>
+    <height>724</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <property name="geometry">
     <rect>
      <x>9</x>
-     <y>79</y>
+     <y>90</y>
      <width>191</width>
      <height>20</height>
     </rect>
@@ -40,7 +40,7 @@
    <property name="geometry">
     <rect>
      <x>310</x>
-     <y>640</y>
+     <y>690</y>
      <width>166</width>
      <height>25</height>
     </rect>
@@ -56,9 +56,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>110</y>
+     <y>120</y>
      <width>461</width>
-     <height>521</height>
+     <height>561</height>
     </rect>
    </property>
    <property name="frameShape">
@@ -70,8 +70,8 @@
    <widget class="QComboBox" name="comboBox_durability">
     <property name="geometry">
      <rect>
-      <x>154</x>
-      <y>42</y>
+      <x>180</x>
+      <y>47</y>
       <width>162</width>
       <height>21</height>
      </rect>
@@ -90,11 +90,34 @@
      </property>
     </item>
    </widget>
+   <widget class="QComboBox" name="comboBox_representation">
+    <property name="geometry">
+     <rect>
+      <x>180</x>
+      <y>80</y>
+      <width>162</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="currentIndex">
+     <number>0</number>
+    </property>
+    <item>
+     <property name="text">
+      <string>XCDR</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>XCDR2</string>
+     </property>
+    </item>
+   </widget>
    <widget class="QLabel" name="label_15">
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>430</y>
+      <y>464</y>
       <width>201</width>
       <height>20</height>
      </rect>
@@ -114,7 +137,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>106</y>
+      <y>140</y>
       <width>441</width>
       <height>101</height>
      </rect>
@@ -242,7 +265,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>80</y>
+      <y>114</y>
       <width>191</width>
       <height>20</height>
      </rect>
@@ -264,7 +287,7 @@
    <widget class="QSpinBox" name="spin_HistoryQos">
     <property name="geometry">
      <rect>
-      <x>154</x>
+      <x>180</x>
       <y>10</y>
       <width>161</width>
       <height>21</height>
@@ -284,7 +307,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>369</y>
+      <y>403</y>
       <width>441</width>
       <height>50</height>
      </rect>
@@ -334,7 +357,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>220</y>
+      <y>254</y>
       <width>181</width>
       <height>20</height>
      </rect>
@@ -357,7 +380,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>460</y>
+      <y>494</y>
       <width>441</width>
       <height>50</height>
      </rect>
@@ -406,9 +429,9 @@
    <widget class="QCheckBox" name="checkBox_reliable">
     <property name="geometry">
      <rect>
-      <x>340</x>
+      <x>360</x>
       <y>10</y>
-      <width>111</width>
+      <width>91</width>
       <height>26</height>
      </rect>
     </property>
@@ -428,7 +451,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>340</y>
+      <y>374</y>
       <width>211</width>
       <height>20</height>
      </rect>
@@ -486,11 +509,32 @@
      <enum>Qt::AutoText</enum>
     </property>
    </widget>
+   <widget class="QLabel" name="label_17">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>80</y>
+      <width>171</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>13</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>Data representation:</string>
+    </property>
+    <property name="textFormat">
+     <enum>Qt::AutoText</enum>
+    </property>
+   </widget>
    <widget class="QFrame" name="frame_3">
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>250</y>
+      <y>284</y>
       <width>441</width>
       <height>71</height>
      </rect>
@@ -587,8 +631,10 @@
     <zorder>spin_ownershipStrength</zorder>
     <zorder>comboBox_ownership</zorder>
    </widget>
+   <zorder>comboBox_representation</zorder>
    <zorder>label_6</zorder>
    <zorder>label_10</zorder>
+   <zorder>label_17</zorder>
    <zorder>spin_HistoryQos</zorder>
    <zorder>checkBox_reliable</zorder>
    <zorder>label_7</zorder>

--- a/forms/publishdialog.ui
+++ b/forms/publishdialog.ui
@@ -71,7 +71,7 @@
     <property name="geometry">
      <rect>
       <x>180</x>
-      <y>47</y>
+      <y>44</y>
       <width>162</width>
       <height>21</height>
      </rect>
@@ -94,7 +94,7 @@
     <property name="geometry">
      <rect>
       <x>180</x>
-      <y>80</y>
+      <y>78</y>
       <width>162</width>
       <height>21</height>
      </rect>
@@ -492,7 +492,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>42</y>
+      <y>44</y>
       <width>131</width>
       <height>20</height>
      </rect>
@@ -513,7 +513,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>80</y>
+      <y>78</y>
       <width>171</width>
       <height>20</height>
      </rect>
@@ -524,7 +524,7 @@
      </font>
     </property>
     <property name="text">
-     <string>Data representation:</string>
+     <string>Data Representation:</string>
     </property>
     <property name="textFormat">
      <enum>Qt::AutoText</enum>

--- a/src/qt/mainwindow.cpp
+++ b/src/qt/mainwindow.cpp
@@ -54,7 +54,7 @@ MainWindow::MainWindow(
     mp_writeThread = new UpdateThread(this, 1);
     mp_writeThread->setMainW(this);
 
-    m_pubsub = new QStandardItemModel(0, 9, this); //2 Rows and 3 Columns
+    m_pubsub = new QStandardItemModel(0, 10, this); //2 Rows and 3 Columns
     m_pubsub->setHorizontalHeaderItem(0, new QStandardItem(QString("Topic")));
     m_pubsub->setHorizontalHeaderItem(1, new QStandardItem(QString("Color")));
     m_pubsub->setHorizontalHeaderItem(2, new QStandardItem(QString("Size")));
@@ -65,13 +65,14 @@ MainWindow::MainWindow(
     m_pubsub->setHorizontalHeaderItem(7, new QStandardItem(QString("Ownership")));
     m_pubsub->setHorizontalHeaderItem(8, new QStandardItem(QString("Durability")));
     m_pubsub->setHorizontalHeaderItem(9, new QStandardItem(QString("Liveliness")));
-
+    m_pubsub->setHorizontalHeaderItem(10, new QStandardItem(QString("Data Representation")));
     ui->tableEndpoint->setModel(m_pubsub);
+
 
 
     QHeaderView* header = ui->tableEndpoint->horizontalHeader();
     header->setSectionResizeMode(QHeaderView::Stretch);
-    header->setMinimumSectionSize(70);
+    header->setMinimumSectionSize(130);
 
     //    ui->tableEndpoint->setColumnWidth(0,60); //Topic
     //    ui->tableEndpoint->setColumnWidth(1,65); //Color
@@ -88,7 +89,7 @@ MainWindow::MainWindow(
     ui->widget_contentFilter->setVisible(false);
 
     // The Participant is created when Start is pressed or when an Endpoint is created
-    
+
     ShapesDemoLogConsumer::register_new_consumer(this);
 }
 
@@ -270,6 +271,15 @@ void MainWindow::addPublisherToTable(
         items.append(new QStandardItem("MAN_TOPIC"));
     }
 
+    //DATA REPRESENTATION
+    if (spub->m_dw_qos.representation().m_value.at(0) == eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION)
+    {
+        items.append(new QStandardItem("XCDR"));
+    }
+    else if (spub->m_dw_qos.representation().m_value.at(0) == eprosima::fastdds::dds::XCDR2_DATA_REPRESENTATION)
+    {
+        items.append(new QStandardItem("XCDR2"));
+    }
 
     m_pubsub->appendRow(items);
     SD_Endpoint sdend;
@@ -353,6 +363,8 @@ void MainWindow::addSubscriberToTable(
     {
         items.append(new QStandardItem("MAN_TOPIC"));
     }
+
+    items.append(new QStandardItem("XCDR & XCDR2"));
 
     m_pubsub->appendRow(items);
     SD_Endpoint sdend;
@@ -471,7 +483,8 @@ void MainWindow::on_actionUser_Manual_triggered()
 void MainWindow::on_actionInteroperability_Troubleshooting_triggered()
 {
     //QDesktopServices::openUrl(QUrl("file:///C:/Program Files/eProsima/FastRTPS/doc/pdf/FastRTPS_ShapesDemo_Interoperability_Troubleshooting.pdf"));
-    QDesktopServices::openUrl(QUrl("https://eprosima-shapes-demo.readthedocs.io/en/latest/troubleshooting/troubleshooting.html"));
+    QDesktopServices::openUrl(QUrl(
+                "https://eprosima-shapes-demo.readthedocs.io/en/latest/troubleshooting/troubleshooting.html"));
 
     //QString str(QDir::currentPath());
 

--- a/src/qt/mainwindow.cpp
+++ b/src/qt/mainwindow.cpp
@@ -66,13 +66,13 @@ MainWindow::MainWindow(
     m_pubsub->setHorizontalHeaderItem(8, new QStandardItem(QString("Durability")));
     m_pubsub->setHorizontalHeaderItem(9, new QStandardItem(QString("Liveliness")));
     m_pubsub->setHorizontalHeaderItem(10, new QStandardItem(QString("Data Repr.")));
-    ui->tableEndpoint->setModel(70);
+    ui->tableEndpoint->setModel(m_pubsub);
 
 
 
     QHeaderView* header = ui->tableEndpoint->horizontalHeader();
     header->setSectionResizeMode(QHeaderView::Stretch);
-    header->setMinimumSectionSize(130);
+    header->setMinimumSectionSize(70);
 
     //    ui->tableEndpoint->setColumnWidth(0,60); //Topic
     //    ui->tableEndpoint->setColumnWidth(1,65); //Color

--- a/src/qt/mainwindow.cpp
+++ b/src/qt/mainwindow.cpp
@@ -65,8 +65,8 @@ MainWindow::MainWindow(
     m_pubsub->setHorizontalHeaderItem(7, new QStandardItem(QString("Ownership")));
     m_pubsub->setHorizontalHeaderItem(8, new QStandardItem(QString("Durability")));
     m_pubsub->setHorizontalHeaderItem(9, new QStandardItem(QString("Liveliness")));
-    m_pubsub->setHorizontalHeaderItem(10, new QStandardItem(QString("Data Representation")));
-    ui->tableEndpoint->setModel(m_pubsub);
+    m_pubsub->setHorizontalHeaderItem(10, new QStandardItem(QString("Data Repr.")));
+    ui->tableEndpoint->setModel(70);
 
 
 
@@ -364,7 +364,7 @@ void MainWindow::addSubscriberToTable(
         items.append(new QStandardItem("MAN_TOPIC"));
     }
 
-    items.append(new QStandardItem("XCDR & XCDR2"));
+    items.append(new QStandardItem("XCDR1&2"));
 
     m_pubsub->appendRow(items);
     SD_Endpoint sdend;

--- a/src/qt/publishdialog.cpp
+++ b/src/qt/publishdialog.cpp
@@ -158,6 +158,21 @@ void PublishDialog::on_button_OkCancel_accepted()
         case 1: SP->m_dw_qos.durability().kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS; break;
     }
 
+    std::cout<<"Create Shape publisher"<<std::endl;
+    //DATA REPRESENTATION
+    switch (this->ui->comboBox_representation->currentIndex())
+    {
+        case 0: {SP->m_dw_qos.representation().m_value.push_back(eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION);
+                std::cout<<"case 0"<<std::endl;
+                 }
+        break;
+        case 1: { SP->m_dw_qos.representation().m_value.push_back(eprosima::fastdds::dds::XCDR2_DATA_REPRESENTATION);
+                std::cout<<"caso 1"<<std::endl;
+                }
+        break;
+    }
+
+
     //OWNERSHIP:
     switch (this->ui->comboBox_ownership->currentIndex())
     {
@@ -305,7 +320,7 @@ void PublishDialog::on_comboBox_ownership_currentIndexChanged(
 
             break;
         }
-        case 1: 
+        case 1:
         {
             this->ui->checkBox_reliable->setChecked(true);
 

--- a/src/qt/publishdialog.cpp
+++ b/src/qt/publishdialog.cpp
@@ -164,13 +164,13 @@ void PublishDialog::on_button_OkCancel_accepted()
         case 0:
         {
             SP->m_dw_qos.representation().m_value.push_back(eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION);
+            break;
         }
-        break;
         case 1:
         {
             SP->m_dw_qos.representation().m_value.push_back(eprosima::fastdds::dds::XCDR2_DATA_REPRESENTATION);
+            break;
         }
-        break;
     }
 
 

--- a/src/qt/publishdialog.cpp
+++ b/src/qt/publishdialog.cpp
@@ -158,17 +158,18 @@ void PublishDialog::on_button_OkCancel_accepted()
         case 1: SP->m_dw_qos.durability().kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS; break;
     }
 
-    std::cout<<"Create Shape publisher"<<std::endl;
     //DATA REPRESENTATION
     switch (this->ui->comboBox_representation->currentIndex())
     {
-        case 0: {SP->m_dw_qos.representation().m_value.push_back(eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION);
-                std::cout<<"case 0"<<std::endl;
-                 }
+        case 0:
+        {
+            SP->m_dw_qos.representation().m_value.push_back(eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION);
+        }
         break;
-        case 1: { SP->m_dw_qos.representation().m_value.push_back(eprosima::fastdds::dds::XCDR2_DATA_REPRESENTATION);
-                std::cout<<"caso 1"<<std::endl;
-                }
+        case 1:
+        {
+            SP->m_dw_qos.representation().m_value.push_back(eprosima::fastdds::dds::XCDR2_DATA_REPRESENTATION);
+        }
         break;
     }
 

--- a/src/qt/subscribedialog.cpp
+++ b/src/qt/subscribedialog.cpp
@@ -111,6 +111,10 @@ void SubscribeDialog::on_buttonBox_accepted()
         case 1: SSub->m_dr_qos.durability().kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS; break;
     }
 
+    //DATA REPRESENTATION
+    SSub->m_dr_qos.type_consistency().representation.m_value.push_back(eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION) ;
+    SSub->m_dr_qos.type_consistency().representation.m_value.push_back(eprosima::fastdds::dds::XCDR2_DATA_REPRESENTATION) ;
+
     //LIVELINESS
     if (this->ui->comboBox_liveliness->currentIndex() == 0)
     {


### PR DESCRIPTION
Add the possibility to configure data representation version in publisher datawriter. 
The subscriber datareader is able to read both representation.
Documentation https://github.com/eProsima/Shapes-Demo-Docs/pull/73