### PR TITLE
Udp sample loss feature 

### DIFF
--- a/forms/participantdialog.ui
+++ b/forms/participantdialog.ui
@@ -104,7 +104,7 @@
    <item row="8" column="4">
     <widget class="QLineEdit" name="lineEdit_server_ip"/>
    </item>
-   <item row="25" column="3">
+   <item row="30" column="3">
     <widget class="QPushButton" name="pushButton_start">
      <property name="focusPolicy">
       <enum>Qt::TabFocus</enum>
@@ -114,7 +114,7 @@
      </property>
     </widget>
    </item>
-   <item row="25" column="4">
+   <item row="30" column="4">
     <widget class="QPushButton" name="pushButton_stop">
      <property name="focusPolicy">
       <enum>Qt::TabFocus</enum>
@@ -176,6 +176,53 @@
     </widget>
    </item>
    <item row="23" column="0">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="24" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Advanced options</string>
+     </property>
+    </widget>
+   </item>
+   <item row="25" column="1">
+    <widget class="QCheckBox" name="lossCheckBox">
+     <property name="text">
+      <string>Abilitate UDP Sample Loss</string>
+     </property>
+    </widget>
+   </item>
+   <item row="25" column="3">
+    <widget class="QSpinBox" name="lossSpin">
+     <property name="specialValueText">
+      <string/>
+     </property>
+     <property name="suffix">
+      <string/>
+     </property>
+     <property name="value">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="25" column="4">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>%</string>
+     </property>
+    </widget>
+   </item>
+   <item row="26" column="0">
     <widget class="QLabel" name="label_12">
      <property name="font">
       <font>
@@ -188,7 +235,7 @@
      </property>
     </widget>
    </item>
-   <item row="24" column="1">
+   <item row="27" column="1">
     <widget class="QCheckBox" name="rosTopicCheckBox">
      <property name="text">
       <string>Use ROS 2 Topics</string>

--- a/forms/participantdialog.ui
+++ b/forms/participantdialog.ui
@@ -198,7 +198,7 @@
    <item row="25" column="1">
     <widget class="QCheckBox" name="lossCheckBox">
      <property name="text">
-      <string>Abilitate UDP Sample Loss</string>
+      <string>Enable UDP Sample Loss</string>
      </property>
     </widget>
    </item>

--- a/forms/participantdialog.ui
+++ b/forms/participantdialog.ui
@@ -211,7 +211,7 @@
       <string/>
      </property>
      <property name="value">
-      <number>30</number>
+      <number>1</number>
      </property>
     </widget>
    </item>

--- a/include/eprosimashapesdemo/qt/participantdialog.h
+++ b/include/eprosimashapesdemo/qt/participantdialog.h
@@ -16,7 +16,7 @@
 #define PARTICIPANTDIALOG_H
 
 #include <QDialog>
-
+#include <QMessageBox>
 namespace Ui {
 class ParticipantDialog;
 } // namespace Ui
@@ -79,6 +79,11 @@ private slots:
     void on_monitorServiceCheckBox_stateChanged(
             int arg1);
 
+    void on_lossCheckBox_stateChanged(
+            int arg1);
+
+    void on_lossSpin_valueChanged(
+        int arg1);
 private:
 
     ShapesDemoOptions* m_options;

--- a/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
+++ b/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
@@ -72,6 +72,8 @@ public:
     uint32_t m_updateIntervalMs;
     uint32_t m_movementSpeed;
     uint32_t m_domainId;
+    uint32_t m_lossPerc;
+    bool m_lossSampleEnabled;
     ShapesDemoOptions()
     {
         m_udp_transport = true;
@@ -88,6 +90,8 @@ public:
         m_domainId = 0;
         m_tcp_type = QString("TCP LAN Server");
         m_monitor_service = false;
+        m_lossPerc = 30;
+        m_lossSampleEnabled = false;
 #ifdef ENABLE_ROS_COMPONENTS
         m_ros2_topic = detect_ros_2_installation();
 #else

--- a/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
+++ b/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
@@ -90,7 +90,7 @@ public:
         m_domainId = 0;
         m_tcp_type = QString("TCP LAN Server");
         m_monitor_service = true;
-        m_lossPerc = 30;
+        m_lossPerc = 1;
         m_lossSampleEnabled = false;
 
 #ifdef ENABLE_ROS_COMPONENTS

--- a/src/qt/participantdialog.cpp
+++ b/src/qt/participantdialog.cpp
@@ -60,10 +60,7 @@ ParticipantDialog::ParticipantDialog(
 #endif // ifdef ENABLE_ROS_COMPONENTS
 
     // Percentage loss Configuration
-    this->ui->lossSpin->setEnabled(m_options->m_lossSampleEnabled);
     this->ui->lossSpin->setValue(m_options->m_lossPerc);
-    this->ui->label_7->setEnabled(false);
-
 
     setEnableState();
     setAttribute ( Qt::WA_DeleteOnClose, true );
@@ -132,6 +129,7 @@ void ParticipantDialog::on_pushButton_start_clicked()
 void ParticipantDialog::on_pushButton_stop_clicked()
 {
     this->mp_mw->on_actionStop_triggered();
+    m_options->m_lossSampleEnabled = false;
     setEnableState();
 }
 
@@ -271,73 +269,74 @@ void ParticipantDialog::on_lossSpin_valueChanged(
 {
     m_options->m_lossPerc = arg1;
     mp_sd->setOptions(*m_options);
-    std::cout<<"perc "<<m_options->m_lossPerc<<std::endl;
+    std::cout << "perc " << m_options->m_lossPerc << std::endl;
 }
 
 void ParticipantDialog::on_lossCheckBox_stateChanged(
         int arg1)
 {
-   if(arg1)
-   {
+    if (arg1)
+    {
         QMessageBox msgBox;
         msgBox.setWindowTitle("Warning");
         msgBox.setText("Enabling this modality results in sample loss! Do you want to continue?");
         msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
         msgBox.setDefaultButton(QMessageBox::Cancel);
         int out_ = msgBox.exec();
-        switch (out_) {
+        switch (out_){
             case QMessageBox::Ok:
             {
                 // Transport Configurations
-                this->ui->IntraprocesscheckBox->setEnabled(!arg1);
-                this->ui->DataSharingcheckBox->setEnabled(!arg1);
-                this->ui->SHMcheckBox->setEnabled(!arg1);
-                this->ui->UDPcheckBox->setEnabled(!arg1);
-                this->ui->TCPcheckBox->setEnabled(!arg1);
-                this->ui->IntraprocesscheckBox->setChecked(true && !arg1);
-                this->ui->DataSharingcheckBox->setChecked(true && !arg1);
-                this->ui->SHMcheckBox->setChecked(true && !arg1);
-                this->ui->UDPcheckBox->setChecked(true && !arg1);
-                this->ui->TCPcheckBox->setChecked(false && !arg1);
-                m_options->m_intraprocess_transport = (true && !arg1);
-                m_options->m_datasharing_transport = (true && !arg1);
-                m_options->m_shm_transport = (true && !arg1);
-                m_options->m_udp_transport = (true && !arg1);
-                m_options->m_tcp_transport = (false && !arg1);
+                this->ui->IntraprocesscheckBox->setEnabled(false);
+                this->ui->DataSharingcheckBox->setEnabled(false);
+                this->ui->SHMcheckBox->setEnabled(false);
+                this->ui->UDPcheckBox->setEnabled(false);
+                this->ui->TCPcheckBox->setEnabled(false);
+                this->ui->IntraprocesscheckBox->setChecked(false);
+                this->ui->DataSharingcheckBox->setChecked(false);
+                this->ui->SHMcheckBox->setChecked(false);
+                this->ui->UDPcheckBox->setChecked(false);
+                this->ui->TCPcheckBox->setChecked(false);
+                m_options->m_intraprocess_transport = (false);
+                m_options->m_datasharing_transport = (false);
+                m_options->m_shm_transport = (false);
+                m_options->m_udp_transport = (false);
+                m_options->m_tcp_transport = (false);
 
-                this->ui->lossSpin->setEnabled(arg1);
-                this->ui->label_7->setEnabled(arg1);
+                this->ui->lossSpin->setEnabled(true);
+                this->ui->label_7->setEnabled(true);
                 m_options->m_lossSampleEnabled = true;
                 mp_sd->setOptions(*m_options);
             }
-                break;
+            break;
             case QMessageBox::Cancel:
             {
                 this->ui->lossCheckBox->setCheckState(Qt::Unchecked);
                 m_options->m_lossSampleEnabled = false;
             }
-                break;
+            break;
             default:
                 // should never be reached
                 break;
         }
     }
-    else{
-        this->ui->IntraprocesscheckBox->setEnabled(!arg1);
-        this->ui->DataSharingcheckBox->setEnabled(!arg1);
-        this->ui->SHMcheckBox->setEnabled(!arg1);
-        this->ui->UDPcheckBox->setEnabled(!arg1);
-        this->ui->TCPcheckBox->setEnabled(!arg1);
-        this->ui->IntraprocesscheckBox->setChecked(true && !arg1);
-        this->ui->DataSharingcheckBox->setChecked(true && !arg1);
-        this->ui->SHMcheckBox->setChecked(true && !arg1);
-        this->ui->UDPcheckBox->setChecked(true && !arg1);
-        this->ui->TCPcheckBox->setChecked(false && !arg1);
-        m_options->m_intraprocess_transport = (true && !arg1);
-        m_options->m_datasharing_transport = (true && !arg1);
-        m_options->m_shm_transport = (true && !arg1);
-        m_options->m_udp_transport = (true && !arg1);
-        m_options->m_tcp_transport = (false && !arg1);
+    else
+    {
+        this->ui->IntraprocesscheckBox->setEnabled(true);
+        this->ui->DataSharingcheckBox->setEnabled(true);
+        this->ui->SHMcheckBox->setEnabled(true);
+        this->ui->UDPcheckBox->setEnabled(true);
+        this->ui->TCPcheckBox->setEnabled(true);
+        this->ui->IntraprocesscheckBox->setChecked(true);
+        this->ui->DataSharingcheckBox->setChecked(true);
+        this->ui->SHMcheckBox->setChecked(true);
+        this->ui->UDPcheckBox->setChecked(true);
+        this->ui->TCPcheckBox->setChecked(false);
+        m_options->m_intraprocess_transport = (true);
+        m_options->m_datasharing_transport = (true);
+        m_options->m_shm_transport = (true);
+        m_options->m_udp_transport = (true);
+        m_options->m_tcp_transport = (false);
 
         this->ui->lossSpin->setEnabled(arg1);
         this->ui->label_7->setEnabled(arg1);

--- a/src/qt/participantdialog.cpp
+++ b/src/qt/participantdialog.cpp
@@ -59,6 +59,11 @@ ParticipantDialog::ParticipantDialog(
     this->ui->rosTopicCheckBox->setVisible(false);
 #endif // ifdef ENABLE_ROS_COMPONENTS
 
+    // Percentage loss Configuration
+    this->ui->lossSpin->setEnabled(m_options->m_lossSampleEnabled);
+    this->ui->lossSpin->setValue(m_options->m_lossPerc);
+    this->ui->label_7->setEnabled(false);
+
 
     setEnableState();
     setAttribute ( Qt::WA_DeleteOnClose, true );
@@ -102,6 +107,9 @@ void ParticipantDialog::setEnableState()
     this->ui->SHMcheckBox->setEnabled(mb_started);
     this->ui->UDPcheckBox->setEnabled(mb_started);
     this->ui->TCPcheckBox->setEnabled(mb_started);
+    this->ui->lossCheckBox->setEnabled(mb_started);
+    this->ui->lossSpin->setEnabled(this->ui->lossCheckBox->isChecked());
+    this->ui->label_7->setEnabled(this->ui->lossCheckBox->isChecked());
 
     // Enable in Running
     this->ui->pushButton_stop->setEnabled(!mb_started);
@@ -256,4 +264,84 @@ void ParticipantDialog::on_monitorServiceCheckBox_stateChanged(
 {
     m_options->m_monitor_service = arg1;
     mp_sd->setOptions(*m_options);
+}
+
+void ParticipantDialog::on_lossSpin_valueChanged(
+        int arg1)
+{
+    m_options->m_lossPerc = arg1;
+    mp_sd->setOptions(*m_options);
+    std::cout<<"perc "<<m_options->m_lossPerc<<std::endl;
+}
+
+void ParticipantDialog::on_lossCheckBox_stateChanged(
+        int arg1)
+{
+   if(arg1)
+   {
+        QMessageBox msgBox;
+        msgBox.setWindowTitle("Warning");
+        msgBox.setText("Enabling this modality results in sample loss! Do you want to continue?");
+        msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+        msgBox.setDefaultButton(QMessageBox::Cancel);
+        int out_ = msgBox.exec();
+        switch (out_) {
+            case QMessageBox::Ok:
+            {
+                // Transport Configurations
+                this->ui->IntraprocesscheckBox->setEnabled(!arg1);
+                this->ui->DataSharingcheckBox->setEnabled(!arg1);
+                this->ui->SHMcheckBox->setEnabled(!arg1);
+                this->ui->UDPcheckBox->setEnabled(!arg1);
+                this->ui->TCPcheckBox->setEnabled(!arg1);
+                this->ui->IntraprocesscheckBox->setChecked(true && !arg1);
+                this->ui->DataSharingcheckBox->setChecked(true && !arg1);
+                this->ui->SHMcheckBox->setChecked(true && !arg1);
+                this->ui->UDPcheckBox->setChecked(true && !arg1);
+                this->ui->TCPcheckBox->setChecked(false && !arg1);
+                m_options->m_intraprocess_transport = (true && !arg1);
+                m_options->m_datasharing_transport = (true && !arg1);
+                m_options->m_shm_transport = (true && !arg1);
+                m_options->m_udp_transport = (true && !arg1);
+                m_options->m_tcp_transport = (false && !arg1);
+
+                this->ui->lossSpin->setEnabled(arg1);
+                this->ui->label_7->setEnabled(arg1);
+                m_options->m_lossSampleEnabled = true;
+                mp_sd->setOptions(*m_options);
+            }
+                break;
+            case QMessageBox::Cancel:
+            {
+                this->ui->lossCheckBox->setCheckState(Qt::Unchecked);
+                m_options->m_lossSampleEnabled = false;
+            }
+                break;
+            default:
+                // should never be reached
+                break;
+        }
+    }
+    else{
+        this->ui->IntraprocesscheckBox->setEnabled(!arg1);
+        this->ui->DataSharingcheckBox->setEnabled(!arg1);
+        this->ui->SHMcheckBox->setEnabled(!arg1);
+        this->ui->UDPcheckBox->setEnabled(!arg1);
+        this->ui->TCPcheckBox->setEnabled(!arg1);
+        this->ui->IntraprocesscheckBox->setChecked(true && !arg1);
+        this->ui->DataSharingcheckBox->setChecked(true && !arg1);
+        this->ui->SHMcheckBox->setChecked(true && !arg1);
+        this->ui->UDPcheckBox->setChecked(true && !arg1);
+        this->ui->TCPcheckBox->setChecked(false && !arg1);
+        m_options->m_intraprocess_transport = (true && !arg1);
+        m_options->m_datasharing_transport = (true && !arg1);
+        m_options->m_shm_transport = (true && !arg1);
+        m_options->m_udp_transport = (true && !arg1);
+        m_options->m_tcp_transport = (false && !arg1);
+
+        this->ui->lossSpin->setEnabled(arg1);
+        this->ui->label_7->setEnabled(arg1);
+        m_options->m_lossSampleEnabled = false;
+        mp_sd->setOptions(*m_options);
+    }
 }

--- a/src/qt/participantdialog.cpp
+++ b/src/qt/participantdialog.cpp
@@ -269,7 +269,6 @@ void ParticipantDialog::on_lossSpin_valueChanged(
 {
     m_options->m_lossPerc = arg1;
     mp_sd->setOptions(*m_options);
-    std::cout << "perc " << m_options->m_lossPerc << std::endl;
 }
 
 void ParticipantDialog::on_lossCheckBox_stateChanged(

--- a/src/shapesdemo/ShapesDemo.cpp
+++ b/src/shapesdemo/ShapesDemo.cpp
@@ -25,6 +25,7 @@
 #include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.h>
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
+#include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.h>
 #include <fastrtps/config.h> // FASTDDS_STATISTICS availability
 #include <fastrtps/utils/IPLocator.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
@@ -145,6 +146,17 @@ bool ShapesDemo::init()
             // Configure UDP Transport
             std::shared_ptr<UDPv4TransportDescriptor> descriptor = std::make_shared<UDPv4TransportDescriptor>();
             qos.transport().user_transports.push_back(descriptor);
+        }
+        else if (m_options.m_lossSampleEnabled)
+        {
+            std::shared_ptr<UDPv4TransportDescriptor> descriptor = std::make_shared<UDPv4TransportDescriptor>();
+            qos.transport().user_transports.push_back(descriptor);
+            // Configure UDP Transport with Sample Loss
+            auto udp_lossy_descriptor = std::make_shared<test_UDPv4TransportDescriptor>();
+            udp_lossy_descriptor->dropDataMessagesPercentage = m_options.m_lossPerc;
+            qos.transport().use_builtin_transports = false;
+            qos.transport().user_transports.push_back(udp_lossy_descriptor);
+            std::cout<<"sample loss "<<m_options.m_lossPerc<<std::endl;
         }
 
         // TCP

--- a/src/shapesdemo/ShapesDemo.cpp
+++ b/src/shapesdemo/ShapesDemo.cpp
@@ -147,16 +147,14 @@ bool ShapesDemo::init()
             std::shared_ptr<UDPv4TransportDescriptor> descriptor = std::make_shared<UDPv4TransportDescriptor>();
             qos.transport().user_transports.push_back(descriptor);
         }
-        else if (m_options.m_lossSampleEnabled)
+
+        // UDP SAMPLE LOSS
+        if (m_options.m_lossSampleEnabled)
         {
-            std::shared_ptr<UDPv4TransportDescriptor> descriptor = std::make_shared<UDPv4TransportDescriptor>();
-            qos.transport().user_transports.push_back(descriptor);
             // Configure UDP Transport with Sample Loss
             auto udp_lossy_descriptor = std::make_shared<test_UDPv4TransportDescriptor>();
             udp_lossy_descriptor->dropDataMessagesPercentage = m_options.m_lossPerc;
-            qos.transport().use_builtin_transports = false;
             qos.transport().user_transports.push_back(udp_lossy_descriptor);
-            std::cout<<"sample loss "<<m_options.m_lossPerc<<std::endl;
         }
 
         // TCP
@@ -192,7 +190,8 @@ bool ShapesDemo::init()
 
         if (!m_options.m_shm_transport &&
                 !m_options.m_udp_transport &&
-                !m_options.m_tcp_transport)
+                !m_options.m_tcp_transport &&
+                !m_options.m_lossSampleEnabled)
         {
             m_mainWindow->addMessageToOutput(
                 QString("No Transport configured, using Fast DDS transports by default"), true);
@@ -220,7 +219,8 @@ bool ShapesDemo::init()
                 "PDP_PACKETS_TOPIC;" \
                 "EDP_PACKETS_TOPIC;" \
                 "DISCOVERY_TOPIC;" \
-                "PHYSICAL_DATA_TOPIC");
+                "PHYSICAL_DATA_TOPIC;" \
+                "MONITOR_SERVICE_TOPIC");
 
             // In case the Statistics are not compiled, show an error
 #ifndef FASTDDS_STATISTICS


### PR DESCRIPTION
Udp sample loss feature. 
To run it: 
- Open a terminal and run ShapesDemo. 
- In Options>Participant Configuration select 'Enable UDP sample loss' and press 'Ok' in the popup window.
- Select 'Activate Monitor Service'.
- Create a publisher.
- Open a new terminal and run ShapesDemo.
- In Options>Participant Configuration select 'Activate Monitor Service'.
- Create a subscriber.
- Open Monitor Service application. You can download it here: http://jenkins.eprosima.com:8080/job/ubuntu-fastdds-monitor-installer/75/
- After setting the application, check the report of the samples lost in the 'Problem' section.

Documentation: https://github.com/eProsima/Shapes-Demo-Docs/pull/77
