### PR TITLE
[20176] Downgrade cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 ###############################################################################
 # CMake build rules for ShapesDemo
 ###############################################################################
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.20)
 
 
 file(READ version.pri SHAPESVERSION)


### PR DESCRIPTION
Reduce CMake minimum version required for Fast DDS compatibility against RHEL 9.