### PR TITLE
[20176] Regenerate Fast DDS docs example types due to Gen release v3.2.1

### DIFF
--- a/types/ShapePubSubTypes.cxx
+++ b/types/ShapePubSubTypes.cxx
@@ -36,7 +36,7 @@ ShapeTypePubSubType::ShapeTypePubSubType()
     setName("ShapeType");
     uint32_t type_size =
 #if FASTCDR_VERSION_MAJOR == 1
-        ShapeType::getMaxCdrSerializedSize();
+        static_cast<uint32_t>(ShapeType::getMaxCdrSerializedSize());
 #else
         ShapeType_max_cdr_typesize;
 #endif
@@ -139,23 +139,24 @@ std::function<uint32_t()> ShapeTypePubSubType::getSerializedSizeProvider(
     return [data, data_representation]() -> uint32_t
            {
 #if FASTCDR_VERSION_MAJOR == 1
-                return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<ShapeType*>(data))) +
+               static_cast<void>(data_representation);
+               return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<ShapeType*>(data))) +
                       4u /*encapsulation*/;
 #else
-                try
-                {
-                    eprosima::fastcdr::CdrSizeCalculator calculator(
-                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                    size_t current_alignment {0};
-                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                *static_cast<ShapeType*>(data), current_alignment)) +
-                            4u /*encapsulation*/;
-                }
-                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-                {
-                    return 0;
-                }
+               try
+               {
+                   eprosima::fastcdr::CdrSizeCalculator calculator(
+                       data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                       eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                   size_t current_alignment {0};
+                   return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                               *static_cast<ShapeType*>(data), current_alignment)) +
+                           4u /*encapsulation*/;
+               }
+               catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+               {
+                   return 0;
+               }
 #endif // FASTCDR_VERSION_MAJOR == 1
            };
 }


### PR DESCRIPTION
This PR regenerates the Shape types.
This is needed to introduce the Fast DDS Gen release v3.2.1 changes.