### PR TITLE
[20306] Add an auto fill type information check

### DIFF
--- a/forms/participantdialog.ui
+++ b/forms/participantdialog.ui
@@ -196,13 +196,20 @@
     </widget>
    </item>
    <item row="25" column="1">
+    <widget class="QCheckBox" name="typeinformationCheckBox">
+     <property name="text">
+      <string>Autofill type information</string>
+     </property>
+    </widget>
+   </item>
+   <item row="26" column="1">
     <widget class="QCheckBox" name="lossCheckBox">
      <property name="text">
       <string>Enable UDP Sample Loss</string>
      </property>
     </widget>
    </item>
-   <item row="25" column="3">
+   <item row="26" column="3">
     <widget class="QSpinBox" name="lossSpin">
      <property name="specialValueText">
       <string/>
@@ -215,14 +222,14 @@
      </property>
     </widget>
    </item>
-   <item row="25" column="4">
+   <item row="26" column="4">
     <widget class="QLabel" name="label_7">
      <property name="text">
       <string>%</string>
      </property>
     </widget>
    </item>
-   <item row="26" column="0">
+   <item row="27" column="0">
     <widget class="QLabel" name="label_12">
      <property name="font">
       <font>
@@ -235,7 +242,7 @@
      </property>
     </widget>
    </item>
-   <item row="27" column="1">
+   <item row="28" column="1">
     <widget class="QCheckBox" name="rosTopicCheckBox">
      <property name="text">
       <string>Use ROS 2 Topics</string>

--- a/include/eprosimashapesdemo/qt/participantdialog.h
+++ b/include/eprosimashapesdemo/qt/participantdialog.h
@@ -79,6 +79,9 @@ private slots:
     void on_monitorServiceCheckBox_stateChanged(
             int arg1);
 
+    void on_typeinformationCheckBox_stateChanged(
+            int arg1);
+
     void on_lossCheckBox_stateChanged(
             int arg1);
 

--- a/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
+++ b/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
@@ -74,6 +74,8 @@ public:
     uint32_t m_domainId;
     uint32_t m_lossPerc;
     bool m_lossSampleEnabled;
+    bool m_auto_fill_type_information;
+
     ShapesDemoOptions()
     {
         m_udp_transport = true;
@@ -92,6 +94,7 @@ public:
         m_monitor_service = true;
         m_lossPerc = 1;
         m_lossSampleEnabled = false;
+        m_auto_fill_type_information = true;
 
 #ifdef ENABLE_ROS_COMPONENTS
         m_ros2_topic = detect_ros_2_installation();

--- a/src/qt/participantdialog.cpp
+++ b/src/qt/participantdialog.cpp
@@ -59,6 +59,8 @@ ParticipantDialog::ParticipantDialog(
     this->ui->rosTopicCheckBox->setVisible(false);
 #endif // ifdef ENABLE_ROS_COMPONENTS
 
+    this->ui->typeinformationCheckBox->setChecked(m_options->m_auto_fill_type_information);
+
     // Percentage loss Configuration
     this->ui->lossSpin->setValue(m_options->m_lossPerc);
 
@@ -104,6 +106,7 @@ void ParticipantDialog::setEnableState()
     this->ui->SHMcheckBox->setEnabled(mb_started);
     this->ui->UDPcheckBox->setEnabled(mb_started);
     this->ui->TCPcheckBox->setEnabled(mb_started);
+    this->ui->typeinformationCheckBox->setEnabled(mb_started);
     this->ui->lossCheckBox->setEnabled(mb_started);
     this->ui->lossSpin->setEnabled(this->ui->lossCheckBox->isChecked());
     this->ui->label_7->setEnabled(this->ui->lossCheckBox->isChecked());
@@ -268,6 +271,13 @@ void ParticipantDialog::on_lossSpin_valueChanged(
         int arg1)
 {
     m_options->m_lossPerc = arg1;
+    mp_sd->setOptions(*m_options);
+}
+
+void ParticipantDialog::on_typeinformationCheckBox_stateChanged(
+        int arg1)
+{
+    m_options->m_auto_fill_type_information = arg1;
     mp_sd->setOptions(*m_options);
 }
 

--- a/src/shapesdemo/ShapesDemo.cpp
+++ b/src/shapesdemo/ShapesDemo.cpp
@@ -239,7 +239,7 @@ bool ShapesDemo::init()
 
         // If the creation has been correct, register type
         m_isInitialized = true;
-        m_type->auto_fill_type_information(false);
+        m_type->auto_fill_type_information(m_options.m_auto_fill_type_information);
         m_type->auto_fill_type_object(false);
         m_type.register_type(mp_participant);
 #ifdef ENABLE_ROS_COMPONENTS

--- a/src/shapesdemo/ShapesDemo.cpp
+++ b/src/shapesdemo/ShapesDemo.cpp
@@ -239,6 +239,8 @@ bool ShapesDemo::init()
 
         // If the creation has been correct, register type
         m_isInitialized = true;
+        m_type->auto_fill_type_information(false);
+        m_type->auto_fill_type_object(false);
         m_type.register_type(mp_participant);
 #ifdef ENABLE_ROS_COMPONENTS
         m_ros_type.register_type(mp_participant);


### PR DESCRIPTION
This PR adds a check button to avoid sending type information during discovery. Related PRs:
- Fast DDS: eProsima/Fast-DDS#4291
- Shapes Demo Documentation: eProsima/Shapes-Demo-Docs#89