### PR TITLE
[20410] Remove Data-Sharing option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,6 @@ You can modify the following settings:
 - **Same host delivery:**  *Fast DDS* has some features that allow Participants running in the same host or process
   to share resources in order to improve the communication:
   - **Intraprocess:** Allow using Intraprocess delivery when both Endpoints are running in the same process.
-  - **Data Sharing:** Allow using Data Sharing delivery when both Endpoints are running in the same host.
 
 - **Domain:** The user can select different Domain IDs.
   Shapes Demo instances using different Domain IDs will not communicate.

--- a/forms/participantdialog.ui
+++ b/forms/participantdialog.ui
@@ -256,13 +256,6 @@
      </property>
     </widget>
    </item>
-   <item row="12" column="3">
-    <widget class="QCheckBox" name="DataSharingcheckBox">
-     <property name="text">
-      <string>Data Sharing</string>
-     </property>
-    </widget>
-   </item>
    <item row="6" column="1">
     <widget class="QCheckBox" name="SHMcheckBox">
      <property name="text">

--- a/include/eprosimashapesdemo/qt/participantdialog.h
+++ b/include/eprosimashapesdemo/qt/participantdialog.h
@@ -59,9 +59,6 @@ private slots:
     void on_IntraprocesscheckBox_stateChanged(
             int arg1);
 
-    void on_DataSharingcheckBox_stateChanged(
-            int arg1);
-
     void on_SHMcheckBox_stateChanged(
             int arg1);
 

--- a/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
+++ b/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
@@ -60,7 +60,6 @@ public:
     bool m_udp_transport;
     bool m_tcp_transport;
     bool m_intraprocess_transport;
-    bool m_datasharing_transport;
     bool m_shm_transport;
     bool m_statistics;
     bool m_ros2_topic;
@@ -81,7 +80,6 @@ public:
         m_udp_transport = true;
         m_tcp_transport = false;
         m_intraprocess_transport = true;
-        m_datasharing_transport = true;
         m_shm_transport = true;
         m_statistics = true;
         m_listenPort = 5100;
@@ -228,11 +226,6 @@ public:
     Topic* getTopic(
             std::string topic_name);
 
-    bool data_sharing_enable ()
-    {
-        return m_data_sharing_enable;
-    }
-
 private:
 
     std::vector<ShapePublisher*> m_publishers;
@@ -260,7 +253,6 @@ private:
     TypeSupport m_ros_type;
 #endif // ifdef ENABLE_ROS_COMPONENTS
     std::map<std::string, Topic*> m_topics;
-    bool m_data_sharing_enable;
 };
 
 #endif /* SHAPESDEMO_H_ */

--- a/src/qt/participantdialog.cpp
+++ b/src/qt/participantdialog.cpp
@@ -42,7 +42,6 @@ ParticipantDialog::ParticipantDialog(
 
     // Transport Configurations
     this->ui->IntraprocesscheckBox->setChecked(m_options->m_intraprocess_transport);
-    this->ui->DataSharingcheckBox->setChecked(m_options->m_datasharing_transport);
     this->ui->SHMcheckBox->setChecked(m_options->m_shm_transport);
     this->ui->UDPcheckBox->setChecked(m_options->m_udp_transport);
     this->ui->TCPcheckBox->setChecked(m_options->m_tcp_transport);
@@ -102,7 +101,6 @@ void ParticipantDialog::setEnableState()
     }
 #endif // ifdef ENABLE_ROS_COMPONENTS
     this->ui->IntraprocesscheckBox->setEnabled(mb_started);
-    this->ui->DataSharingcheckBox->setEnabled(mb_started);
     this->ui->SHMcheckBox->setEnabled(mb_started);
     this->ui->UDPcheckBox->setEnabled(mb_started);
     this->ui->TCPcheckBox->setEnabled(mb_started);
@@ -221,13 +219,6 @@ void ParticipantDialog::on_IntraprocesscheckBox_stateChanged(
     mp_sd->setOptions(*m_options);
 }
 
-void ParticipantDialog::on_DataSharingcheckBox_stateChanged(
-        int arg1)
-{
-    m_options->m_datasharing_transport = arg1;
-    mp_sd->setOptions(*m_options);
-}
-
 void ParticipantDialog::on_SHMcheckBox_stateChanged(
         int arg1)
 {
@@ -297,17 +288,14 @@ void ParticipantDialog::on_lossCheckBox_stateChanged(
             {
                 // Transport Configurations
                 this->ui->IntraprocesscheckBox->setEnabled(false);
-                this->ui->DataSharingcheckBox->setEnabled(false);
                 this->ui->SHMcheckBox->setEnabled(false);
                 this->ui->UDPcheckBox->setEnabled(false);
                 this->ui->TCPcheckBox->setEnabled(false);
                 this->ui->IntraprocesscheckBox->setChecked(false);
-                this->ui->DataSharingcheckBox->setChecked(false);
                 this->ui->SHMcheckBox->setChecked(false);
                 this->ui->UDPcheckBox->setChecked(false);
                 this->ui->TCPcheckBox->setChecked(false);
                 m_options->m_intraprocess_transport = (false);
-                m_options->m_datasharing_transport = (false);
                 m_options->m_shm_transport = (false);
                 m_options->m_udp_transport = (false);
                 m_options->m_tcp_transport = (false);
@@ -332,17 +320,14 @@ void ParticipantDialog::on_lossCheckBox_stateChanged(
     else
     {
         this->ui->IntraprocesscheckBox->setEnabled(true);
-        this->ui->DataSharingcheckBox->setEnabled(true);
         this->ui->SHMcheckBox->setEnabled(true);
         this->ui->UDPcheckBox->setEnabled(true);
         this->ui->TCPcheckBox->setEnabled(true);
         this->ui->IntraprocesscheckBox->setChecked(true);
-        this->ui->DataSharingcheckBox->setChecked(true);
         this->ui->SHMcheckBox->setChecked(true);
         this->ui->UDPcheckBox->setChecked(true);
         this->ui->TCPcheckBox->setChecked(false);
         m_options->m_intraprocess_transport = (true);
-        m_options->m_datasharing_transport = (true);
         m_options->m_shm_transport = (true);
         m_options->m_udp_transport = (true);
         m_options->m_tcp_transport = (false);

--- a/src/qt/publishdialog.cpp
+++ b/src/qt/publishdialog.cpp
@@ -236,16 +236,6 @@ void PublishDialog::on_button_OkCancel_accepted()
         SP->m_pub_qos.partition().push_back("D");
     }
 
-    // Data Sharing
-    if (this->mp_sd->data_sharing_enable())
-    {
-        SP->m_dw_qos.data_sharing().automatic();
-    }
-    else
-    {
-        SP->m_dw_qos.data_sharing().off();
-    }
-
     // Create Publisher
     if (SP->initPublisher())
     {

--- a/src/qt/subscribedialog.cpp
+++ b/src/qt/subscribedialog.cpp
@@ -233,16 +233,6 @@ void SubscribeDialog::on_buttonBox_accepted()
         SSub->m_shapeHistory.m_filter.m_useContentFilter = true;
     }
 
-    // Data Sharing
-    if (this->mp_sd->data_sharing_enable())
-    {
-        SSub->m_dr_qos.data_sharing().automatic();
-    }
-    else
-    {
-        SSub->m_dr_qos.data_sharing().off();
-    }
-
     // Create Subscriber
     if (SSub->initSubscriber())
     {

--- a/src/shapesdemo/ShapesDemo.cpp
+++ b/src/shapesdemo/ShapesDemo.cpp
@@ -58,7 +58,6 @@ ShapesDemo::ShapesDemo(
 #ifdef ENABLE_ROS_COMPONENTS
     , m_ros_type(new shapes_demo_typesupport::idl::KeylessShapeTypePubSubType())
 #endif // ifdef ENABLE_ROS_COMPONENTS
-    , m_data_sharing_enable(false)
 {
     srand (time(nullptr));
     minX = 0;
@@ -127,9 +126,6 @@ bool ShapesDemo::init()
         library_settings.intraprocess_delivery = m_options.m_intraprocess_transport ?
                 IntraprocessDeliveryType::INTRAPROCESS_FULL : IntraprocessDeliveryType::INTRAPROCESS_OFF;
         xmlparser::XMLProfileManager::library_settings(library_settings);
-
-        // Data Sharing
-        m_data_sharing_enable = m_options.m_datasharing_transport;
 
         // Shared Memory
         if (m_options.m_shm_transport)


### PR DESCRIPTION
Shapes Demo has never worked in data-sharing mode (because the Shape type contains an `unbounded` string).
This PR removes the data-sharing option as it is never used.

@Mergifyio backport 2.6.x 2.10.x 2.12.x 2.13.x

Related documentation PR: 
* eProsima/Shapes-Demo-Docs#100