### PR TITLE
[20495] Regenerate shapes types: Fast DDS Gen v3.3.0

### DIFF
--- a/types/KeylessShapeType.cxx
+++ b/types/KeylessShapeType.cxx
@@ -30,6 +30,8 @@ char dummy;
 
 #if FASTCDR_VERSION_MAJOR > 1
 
+#include "KeylessShapeTypeTypeObject.h"
+
 #include <fastcdr/Cdr.h>
 
 
@@ -47,6 +49,8 @@ namespace idl {
 
 KeylessShapeType::KeylessShapeType()
 {
+    // Just to register all known types
+    registerKeylessShapeTypeTypes();
 }
 
 KeylessShapeType::~KeylessShapeType()

--- a/types/KeylessShapeTypePubSubTypes.cxx
+++ b/types/KeylessShapeTypePubSubTypes.cxx
@@ -35,10 +35,10 @@ namespace shapes_demo_typesupport {
 
         KeylessShapeTypePubSubType::KeylessShapeTypePubSubType()
         {
-            setName("shapes_demo_typesupport::idl::KeylessShapeType");
+            setName("shapes_demo_typesupport::idl::dds_::KeylessShapeType_");
             uint32_t type_size =
         #if FASTCDR_VERSION_MAJOR == 1
-                KeylessShapeType::getMaxCdrSerializedSize();
+                static_cast<uint32_t>(KeylessShapeType::getMaxCdrSerializedSize());
         #else
                 shapes_demo_typesupport_idl_KeylessShapeType_max_cdr_typesize;
         #endif
@@ -141,23 +141,24 @@ namespace shapes_demo_typesupport {
             return [data, data_representation]() -> uint32_t
                    {
         #if FASTCDR_VERSION_MAJOR == 1
-                        return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<KeylessShapeType*>(data))) +
+                       static_cast<void>(data_representation);
+                       return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<KeylessShapeType*>(data))) +
                               4u /*encapsulation*/;
         #else
-                        try
-                        {
-                            eprosima::fastcdr::CdrSizeCalculator calculator(
-                                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                            size_t current_alignment {0};
-                            return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                        *static_cast<KeylessShapeType*>(data), current_alignment)) +
-                                    4u /*encapsulation*/;
-                        }
-                        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-                        {
-                            return 0;
-                        }
+                       try
+                       {
+                           eprosima::fastcdr::CdrSizeCalculator calculator(
+                               data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                               eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                           size_t current_alignment {0};
+                           return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                                       *static_cast<KeylessShapeType*>(data), current_alignment)) +
+                                   4u /*encapsulation*/;
+                       }
+                       catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                       {
+                           return 0;
+                       }
         #endif // FASTCDR_VERSION_MAJOR == 1
                    };
         }

--- a/types/KeylessShapeTypeTypeObject.cxx
+++ b/types/KeylessShapeTypeTypeObject.cxx
@@ -44,9 +44,9 @@ void registerKeylessShapeTypeTypes()
     std::call_once(once_flag, []()
             {
                 TypeObjectFactory *factory = TypeObjectFactory::get_instance();
-                factory->add_type_object("shapes_demo_typesupport::idl::KeylessShapeType", shapes_demo_typesupport::idl::GetKeylessShapeTypeIdentifier(true),
+                factory->add_type_object("shapes_demo_typesupport::idl::dds_::KeylessShapeType_", shapes_demo_typesupport::idl::GetKeylessShapeTypeIdentifier(true),
                         shapes_demo_typesupport::idl::GetKeylessShapeTypeObject(true));
-                factory->add_type_object("shapes_demo_typesupport::idl::KeylessShapeType", shapes_demo_typesupport::idl::GetKeylessShapeTypeIdentifier(false),
+                factory->add_type_object("shapes_demo_typesupport::idl::dds_::KeylessShapeType_", shapes_demo_typesupport::idl::GetKeylessShapeTypeIdentifier(false),
                         shapes_demo_typesupport::idl::GetKeylessShapeTypeObject(false));
 
 
@@ -56,6 +56,8 @@ void registerKeylessShapeTypeTypes()
 
 namespace shapes_demo_typesupport {
     namespace idl {
+
+
         const TypeIdentifier* GetKeylessShapeTypeIdentifier(bool complete)
         {
             const TypeIdentifier * c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("KeylessShapeType", complete);
@@ -182,7 +184,6 @@ namespace shapes_demo_typesupport {
             // TODO Inheritance
             //type_object->minimal().struct_type().header().base_type()._d(EK_MINIMAL);
             //type_object->minimal().struct_type().header().base_type().equivalence_hash()[0..13];
-
             TypeIdentifier identifier;
             identifier._d(EK_MINIMAL);
 
@@ -302,7 +303,6 @@ namespace shapes_demo_typesupport {
             // Header
             type_object->complete().struct_type().header().detail().type_name("KeylessShapeType");
             // TODO inheritance
-
             TypeIdentifier identifier;
             identifier._d(EK_COMPLETE);
 

--- a/types/KeylessShapeTypeTypeObject.h
+++ b/types/KeylessShapeTypeTypeObject.h
@@ -56,6 +56,8 @@ eProsima_user_DllExport void registerKeylessShapeTypeTypes();
 
 namespace shapes_demo_typesupport {
     namespace idl {
+
+
         eProsima_user_DllExport const TypeIdentifier* GetKeylessShapeTypeIdentifier(bool complete = false);
         eProsima_user_DllExport const TypeObject* GetKeylessShapeTypeObject(bool complete = false);
         eProsima_user_DllExport const TypeObject* GetMinimalKeylessShapeTypeObject();

--- a/types/KeylessShapeTypev1.cxx
+++ b/types/KeylessShapeTypev1.cxx
@@ -30,6 +30,8 @@ char dummy;
 
 #if FASTCDR_VERSION_MAJOR == 1
 
+#include "KeylessShapeTypeTypeObject.h"
+
 #include <fastcdr/Cdr.h>
 
 
@@ -103,6 +105,8 @@ KeylessShapeType::KeylessShapeType()
     // long m_shapesize
     m_shapesize = 0;
 
+    // Just to register all known types
+    registerKeylessShapeTypeTypes();
 }
 
 KeylessShapeType::~KeylessShapeType()

--- a/types/KeylessShapeTypev1.h
+++ b/types/KeylessShapeTypev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)

--- a/types/Shape.cxx
+++ b/types/Shape.cxx
@@ -30,6 +30,8 @@ char dummy;
 
 #if FASTCDR_VERSION_MAJOR > 1
 
+#include "ShapeTypeObject.h"
+
 #include <fastcdr/Cdr.h>
 
 
@@ -43,6 +45,8 @@ using namespace eprosima::fastcdr::exception;
 
 ShapeType::ShapeType()
 {
+    // Just to register all known types
+    registerShapeTypes();
 }
 
 ShapeType::~ShapeType()

--- a/types/ShapeTypeObject.cxx
+++ b/types/ShapeTypeObject.cxx
@@ -52,6 +52,8 @@ void registerShapeTypes()
             });
 }
 
+
+
 const TypeIdentifier* GetShapeTypeIdentifier(bool complete)
 {
     const TypeIdentifier * c_identifier = TypeObjectFactory::get_instance()->get_type_identifier("ShapeType", complete);
@@ -178,7 +180,6 @@ const TypeObject* GetMinimalShapeTypeObject()
     // TODO Inheritance
     //type_object->minimal().struct_type().header().base_type()._d(EK_MINIMAL);
     //type_object->minimal().struct_type().header().base_type().equivalence_hash()[0..13];
-
     TypeIdentifier identifier;
     identifier._d(EK_MINIMAL);
 
@@ -320,7 +321,6 @@ const TypeObject* GetCompleteShapeTypeObject()
     // Header
     type_object->complete().struct_type().header().detail().type_name("ShapeType");
     // TODO inheritance
-
     TypeIdentifier identifier;
     identifier._d(EK_COMPLETE);
 

--- a/types/ShapeTypeObject.h
+++ b/types/ShapeTypeObject.h
@@ -54,6 +54,8 @@ using namespace eprosima::fastrtps::types;
 
 eProsima_user_DllExport void registerShapeTypes();
 
+
+
 eProsima_user_DllExport const TypeIdentifier* GetShapeTypeIdentifier(bool complete = false);
 eProsima_user_DllExport const TypeObject* GetShapeTypeObject(bool complete = false);
 eProsima_user_DllExport const TypeObject* GetMinimalShapeTypeObject();

--- a/types/Shapev1.cxx
+++ b/types/Shapev1.cxx
@@ -30,6 +30,8 @@ char dummy;
 
 #if FASTCDR_VERSION_MAJOR == 1
 
+#include "ShapeTypeObject.h"
+
 #include <fastcdr/Cdr.h>
 
 
@@ -99,6 +101,8 @@ ShapeType::ShapeType()
     // long m_shapesize
     m_shapesize = 0;
 
+    // Just to register all known types
+    registerShapeTypes();
 }
 
 ShapeType::~ShapeType()

--- a/types/Shapev1.h
+++ b/types/Shapev1.h
@@ -29,12 +29,13 @@
 
 #include <fastrtps/utils/fixed_size_string.hpp>
 
-#include <stdint.h>
 #include <array>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <map>
-#include <bitset>
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_USER_DLL_EXPORT)


### PR DESCRIPTION
This PR updates the ShapesDemo types according to the latest Fast DDS Gen released v3.3.0 version.