### PR TITLE
[20644] Fix ROS 2 line separator in participant configuration

### DIFF
--- a/forms/participantdialog.ui
+++ b/forms/participantdialog.ui
@@ -176,13 +176,6 @@
     </widget>
    </item>
    <item row="23" column="0">
-    <widget class="Line" name="line_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="24" column="0">
     <widget class="QLabel" name="label_6">
      <property name="font">
       <font>
@@ -195,21 +188,21 @@
      </property>
     </widget>
    </item>
-   <item row="25" column="1">
+   <item row="24" column="1">
     <widget class="QCheckBox" name="typeinformationCheckBox">
      <property name="text">
       <string>Autofill type information</string>
      </property>
     </widget>
    </item>
-   <item row="26" column="1">
+   <item row="25" column="1">
     <widget class="QCheckBox" name="lossCheckBox">
      <property name="text">
       <string>Enable UDP Sample Loss</string>
      </property>
     </widget>
    </item>
-   <item row="26" column="3">
+   <item row="25" column="3">
     <widget class="QSpinBox" name="lossSpin">
      <property name="specialValueText">
       <string/>
@@ -222,10 +215,17 @@
      </property>
     </widget>
    </item>
-   <item row="26" column="4">
+   <item row="25" column="4">
     <widget class="QLabel" name="label_7">
      <property name="text">
       <string>%</string>
+     </property>
+    </widget>
+   </item>
+   <item row="26" column="0">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>

--- a/forms/participantdialog.ui
+++ b/forms/participantdialog.ui
@@ -169,7 +169,7 @@
     </widget>
    </item>
    <item row="22" column="0">
-    <widget class="Line" name="line_5">
+    <widget class="Line" name="line_3">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -223,7 +223,7 @@
     </widget>
    </item>
    <item row="26" column="0">
-    <widget class="Line" name="line_3">
+    <widget class="Line" name="line_5">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>


### PR DESCRIPTION
This PR moves the ROS 2 line to its proper position