### PR TITLE
[20893] Prepare 3.0.x-devel to become master

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
     In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
     Please uncomment following line, adjusting the corresponding target branches for the backport.
 -->
-<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->
+<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->
 
 <!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
 <!-- Fixes #(issue) -->
@@ -31,6 +31,11 @@ Related implementation PR:
 -->
 
 ## Contributor Checklist
+
+<!--
+    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
+    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
+-->
 
 - [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
 - [ ] Changes do not break current interoperability.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,11 @@ on:
       fastdds_branch:
         description: 'Fast-DDS branch to be used'
         required: false
-        default: '3.0.x-devel'
+        default: 'master'
   pull_request:
   push:
     branches:
-      - 3.0.x-devel
+      - master
   schedule:
     - cron: '0 0 * * *'
 
@@ -61,7 +61,7 @@ jobs:
         with:
           foonathan-memory-vendor-branch: ${{ github.event.inputs.foonathan_memory_vendor_branch || 'master' }}
           fastcdr-branch: ${{ matrix.fastcdr_version }}
-          fastdds-branch: ${{ github.event.inputs.fastdds_branch || '3.0.x-devel' }}
+          fastdds-branch: ${{ github.event.inputs.fastdds_branch || 'master' }}
 
       - uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
@@ -126,7 +126,7 @@ jobs:
         with:
           foonathan-memory-vendor-branch: ${{ github.event.inputs.foonathan_memory_vendor_branch || 'master' }}
           fastcdr-branch: ${{ matrix.fastcdr_version }}
-          fastdds-branch: ${{ github.event.inputs.fastdds_branch || '3.0.x-devel' }}
+          fastdds-branch: ${{ github.event.inputs.fastdds_branch || 'master' }}
 
       - uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -3,16 +3,19 @@ on:
   push:
     branches:
       - 'master'
+      - '2.14.x'
 
 jobs:
-  mirror_job:
+  mirror_job_master:
+    if: github.ref == 'refs/heads/master'
     name: Mirror master branch to latest minor branches
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         dest_branch:
-          - '2.14.x'
+          - '3.0.x'
+          - '3.x'
     steps:
     - name: Mirror action step
       id: mirror
@@ -20,4 +23,22 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         source: 'master'
+        dest: ${{ matrix.dest_branch }}
+
+  mirror_job_2_x:
+    if: github.ref == 'refs/heads/2.14.x'
+    name: Mirror 2.14.x branch to latest minor branches
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dest_branch:
+          - '2.x'
+    steps:
+    - name: Mirror action step
+      id: mirror
+      uses: eProsima/eProsima-CI/external/mirror-branch-action@main
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        source: '2.14.x'
         dest: ${{ matrix.dest_branch }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # eProsima Fast DDS Shapes Demo
 
+<!-- TODO(eduponz): Remove this before releasing v3.0.0 -->
+> [!WARNING]
+> **In preparation for v3.0.0, Fast DDS' master branch is undergoing major changes entailing API breaks.**
+> **Until Fast DDS v3.0.0 is released, it is strongly advisable to use the latest stable branch, [2.14.x](https://github.com/eProsima/Fast-DDS/tree/2.14.x)**
+
 eProsima Shapes Demo is an application in which Publishers and Subscribers are shapes of different colors and sizes
 moving on a board.
 Each shape refers to its own topic: Square, Triangle or Circle.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR prepares the 3.0.x-devel branch to become Fast DDS Docs master

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#4723

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- [x] Changes do not break current interoperability.
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    * Related documentation PR: eProsima/Shapes-Demo-Docs#109 -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
