### PR TITLE
[21053] Move DR TypeConsistencyEnforcement & DataRepresentation from TypeConsistency to DataReaderQos

### DIFF
--- a/src/qt/subscribedialog.cpp
+++ b/src/qt/subscribedialog.cpp
@@ -112,8 +112,8 @@ void SubscribeDialog::on_buttonBox_accepted()
     }
 
     //DATA REPRESENTATION
-    SSub->m_dr_qos.type_consistency().representation.m_value.push_back(eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION) ;
-    SSub->m_dr_qos.type_consistency().representation.m_value.push_back(eprosima::fastdds::dds::XCDR2_DATA_REPRESENTATION) ;
+    SSub->m_dr_qos.representation().m_value.push_back(eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION) ;
+    SSub->m_dr_qos.representation().m_value.push_back(eprosima::fastdds::dds::XCDR2_DATA_REPRESENTATION) ;
 
     //LIVELINESS
     if (this->ui->comboBox_liveliness->currentIndex() == 0)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR updates the usage of DR qos DataRepresentation according to the changes introduced in:
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* eProsima/Fast-DDS#4823

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- [x] Changes do not break current interoperability.
- __N/A__ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- __N/A__ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
