### PR TITLE
[21183] Adjust for `const` qualification of all data related inputs in DataWriter APIs

### DIFF
--- a/types/KeylessShapeTypePubSubTypes.cxx
+++ b/types/KeylessShapeTypePubSubTypes.cxx
@@ -59,11 +59,11 @@ namespace shapes_demo_typesupport {
         }
 
         bool KeylessShapeTypePubSubType::serialize(
-                void* data,
+                const void* const data,
                 SerializedPayload_t* payload,
                 DataRepresentationId_t data_representation)
         {
-            KeylessShapeType* p_type = static_cast<KeylessShapeType*>(data);
+            const KeylessShapeType* p_type = static_cast<const KeylessShapeType*>(data);
 
             // Object that manages the raw buffer.
             eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -135,7 +135,7 @@ namespace shapes_demo_typesupport {
         }
 
         std::function<uint32_t()> KeylessShapeTypePubSubType::getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 DataRepresentationId_t data_representation)
         {
             return [data, data_representation]() -> uint32_t
@@ -152,7 +152,7 @@ namespace shapes_demo_typesupport {
                                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                            size_t current_alignment {0};
                            return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                       *static_cast<KeylessShapeType*>(data), current_alignment)) +
+                                       *static_cast<const KeylessShapeType*>(data), current_alignment)) +
                                    4u /*encapsulation*/;
                        }
                        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -175,7 +175,7 @@ namespace shapes_demo_typesupport {
         }
 
         bool KeylessShapeTypePubSubType::getKey(
-                void* data,
+                const void* const data,
                 InstanceHandle_t* handle,
                 bool force_md5)
         {
@@ -184,7 +184,7 @@ namespace shapes_demo_typesupport {
                 return false;
             }
 
-            KeylessShapeType* p_type = static_cast<KeylessShapeType*>(data);
+            const KeylessShapeType* p_type = static_cast<const KeylessShapeType*>(data);
 
             // Object that manages the raw buffer.
             eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/types/KeylessShapeTypePubSubTypes.h
+++ b/types/KeylessShapeTypePubSubTypes.h
@@ -57,14 +57,14 @@ namespace shapes_demo_typesupport
             eProsima_user_DllExport ~KeylessShapeTypePubSubType() override;
 
             eProsima_user_DllExport bool serialize(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::SerializedPayload_t* payload) override
             {
                 return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
             }
 
             eProsima_user_DllExport bool serialize(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::SerializedPayload_t* payload,
                     eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -73,17 +73,17 @@ namespace shapes_demo_typesupport
                     void* data) override;
 
             eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                    void* data) override
+                    const void* const data) override
             {
                 return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
             }
 
             eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
             eProsima_user_DllExport bool getKey(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                     bool force_md5 = false) override;
 

--- a/types/ShapePubSubTypes.cxx
+++ b/types/ShapePubSubTypes.cxx
@@ -57,11 +57,11 @@ ShapeTypePubSubType::~ShapeTypePubSubType()
 }
 
 bool ShapeTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ShapeType* p_type = static_cast<ShapeType*>(data);
+    const ShapeType* p_type = static_cast<const ShapeType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool ShapeTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ShapeTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> ShapeTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ShapeType*>(data), current_alignment)) +
+                               *static_cast<const ShapeType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void ShapeTypePubSubType::deleteData(
 }
 
 bool ShapeTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool ShapeTypePubSubType::getKey(
         return false;
     }
 
-    ShapeType* p_type = static_cast<ShapeType*>(data);
+    const ShapeType* p_type = static_cast<const ShapeType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/types/ShapePubSubTypes.h
+++ b/types/ShapePubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~ShapeTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adjusts Fast DDS Docs for:

* eProsima/Fast-DDS#4960

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- [x] Changes do not break current interoperability.
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
