### PR TITLE
[21229] Remove windows nightly job for 2.6.x

### DIFF
--- a/.github/workflows/nightly-windows-ci.yml
+++ b/.github/workflows/nightly-windows-ci.yml
@@ -69,18 +69,4 @@ jobs:
       fastdds-branch: '2.10.x'
       run-build: true
 
-  nightly-windows-ci-2_6_x:
-    strategy:
-      fail-fast: false
-      matrix:
-        vs-toolset:
-          - 'v141'
-          - 'v142'
-    uses: eProsima/ShapesDemo/.github/workflows/reusable-windows-ci.yml@2.6.x
-    with:
-      os-version: 'windows-2019'
-      vs.toolset: ${{ matrix.vs-toolset }}
-      label: 'nightly-windows-${{ matrix.vs-toolset }}-ci-2.6.x'
-      shapes-demo-branch: '2.6.x'
-      fastdds-branch: '2.6.x'
-      run-build: true
+  # There is no job for windows in 2.6.x

--- a/.github/workflows/nightly-windows-ci.yml
+++ b/.github/workflows/nightly-windows-ci.yml
@@ -68,5 +68,3 @@ jobs:
       shapes-demo-branch: '2.10.x'
       fastdds-branch: '2.10.x'
       run-build: true
-
-  # There is no job for windows in 2.6.x


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PRs removes windows nightly job for branch 2.6.x
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- [x] Changes do not break current interoperability.
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- **N/A** CI passes without warnings or errors.
