### PR TITLE
[21229] Fix nightly jobs and move 2.6.x to weekly CI

### DIFF
--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -9,7 +9,7 @@ jobs:
   nightly-ubuntu-ci-master:
     uses: eProsima/ShapesDemo/.github/workflows/reusable-ubuntu-ci.yml@master
     with:
-      os-image: 'ubuntu-22.04'
+      os-version: 'ubuntu-22.04'
       label: 'nightly-ubuntu-ci-master'
       shapes-demo-branch: 'master'
       fastdds-branch: 'master'
@@ -19,7 +19,7 @@ jobs:
   nightly-ubuntu-ci-2_14_x:
     uses: eProsima/ShapesDemo/.github/workflows/reusable-ubuntu-ci.yml@2.14.x
     with:
-      os-image: 'ubuntu-22.04'
+      os-version: 'ubuntu-22.04'
       label: 'nightly-ubuntu-ci-2.14.x'
       shapes-demo-branch: '2.14.x'
       fastdds-branch: '2.14.x'
@@ -29,7 +29,7 @@ jobs:
   nightly-ubuntu-ci-2_13_x:
     uses: eProsima/ShapesDemo/.github/workflows/reusable-ubuntu-ci.yml@2.13.x
     with:
-      os-image: 'ubuntu-22.04'
+      os-version: 'ubuntu-22.04'
       label: 'nightly-ubuntu-ci-2.13.x'
       shapes-demo-branch: '2.13.x'
       fastdds-branch: '2.13.x'
@@ -39,7 +39,7 @@ jobs:
   nightly-ubuntu-ci-2_10_x:
     uses: eProsima/ShapesDemo/.github/workflows/reusable-ubuntu-ci.yml@2.10.x
     with:
-      os-image: 'ubuntu-22.04'
+      os-version: 'ubuntu-22.04'
       label: 'nightly-ubuntu-ci-2.10.x'
       shapes-demo-branch: '2.10.x'
       fastdds-branch: '2.10.x'
@@ -49,7 +49,7 @@ jobs:
   nightly-ubuntu-ci-2_6_x:
     uses: eProsima/ShapesDemo/.github/workflows/reusable-ubuntu-ci.yml@2.6.x
     with:
-      os-image: 'ubuntu-20.04'
+      os-version: 'ubuntu-20.04'
       label: 'nightly-ubuntu-ci-2.6.x'
       shapes-demo-branch: '2.6.x'
       fastdds-branch: '2.6.x'

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -45,13 +45,3 @@ jobs:
       fastdds-branch: '2.10.x'
       run-build: true
       use-ccache: false
-
-  nightly-ubuntu-ci-2_6_x:
-    uses: eProsima/ShapesDemo/.github/workflows/reusable-ubuntu-ci.yml@2.6.x
-    with:
-      os-version: 'ubuntu-20.04'
-      label: 'nightly-ubuntu-ci-2.6.x'
-      shapes-demo-branch: '2.6.x'
-      fastdds-branch: '2.6.x'
-      run-build: true
-      use-ccache: false

--- a/.github/workflows/nightly-windows-ci.yml
+++ b/.github/workflows/nightly-windows-ci.yml
@@ -15,7 +15,7 @@ jobs:
     uses: eProsima/ShapesDemo/.github/workflows/reusable-windows-ci.yml@master
     with:
       os-version: 'windows-2019'
-      vs.toolset: ${{ matrix.vs-toolset }}
+      vs-toolset: ${{ matrix.vs-toolset }}
       label: 'nightly-windows-${{ matrix.vs-toolset }}-ci-master'
       shapes-demo-branch: 'master'
       fastdds-branch: 'master'
@@ -31,7 +31,7 @@ jobs:
     uses: eProsima/ShapesDemo/.github/workflows/reusable-windows-ci.yml@2.14.x
     with:
       os-version: 'windows-2019'
-      vs.toolset: ${{ matrix.vs-toolset }}
+      vs-toolset: ${{ matrix.vs-toolset }}
       label: 'nightly-windows-${{ matrix.vs-toolset }}-ci-2.14.x'
       shapes-demo-branch: '2.14.x'
       fastdds-branch: '2.14.x'
@@ -47,7 +47,7 @@ jobs:
     uses: eProsima/ShapesDemo/.github/workflows/reusable-windows-ci.yml@2.13.x
     with:
       os-version: 'windows-2019'
-      vs.toolset: ${{ matrix.vs-toolset }}
+      vs-toolset: ${{ matrix.vs-toolset }}
       label: 'nightly-windows-${{ matrix.vs-toolset }}-ci-2.13.x'
       shapes-demo-branch: '2.13.x'
       fastdds-branch: '2.13.x'
@@ -63,7 +63,7 @@ jobs:
     uses: eProsima/ShapesDemo/.github/workflows/reusable-windows-ci.yml@2.10.x
     with:
       os-version: 'windows-2019'
-      vs.toolset: ${{ matrix.vs-toolset }}
+      vs-toolset: ${{ matrix.vs-toolset }}
       label: 'nightly-windows-${{ matrix.vs-toolset }}-ci-2.10.x'
       shapes-demo-branch: '2.10.x'
       fastdds-branch: '2.10.x'

--- a/.github/workflows/weekly-ubuntu-ci.yml
+++ b/.github/workflows/weekly-ubuntu-ci.yml
@@ -1,0 +1,17 @@
+name: Shapes Demo Ubuntu CI (weekly)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * 1' # Run at minute 0 on Monday
+
+jobs:
+  weekly-ubuntu-ci-2_6_x:
+    uses: eProsima/ShapesDemo/.github/workflows/reusable-ubuntu-ci.yml@2.6.x
+    with:
+      os-version: 'ubuntu-20.04'
+      label: 'weekly-ubuntu-ci-2.6.x'
+      shapes-demo-branch: '2.6.x'
+      fastdds-branch: '2.6.x'
+      run-build: true
+      use-ccache: false


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Ubuntu nightly job was failing due to `os-image`-`os-version` name mismatched, and Windows job was failing too due to `vs.toolset`-`vs-toolset` name mismatched.
This PR fixes it and moves `2.6.x` related job to weekly CI
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- **N/A** Changes do not break current interoperability.
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- N/A CI passes without warnings or errors.
