### PR TITLE
[21137] Account for changes on RTPS writer refactor

### DIFF
--- a/src/shapesdemo/ShapePublisher.cpp
+++ b/src/shapesdemo/ShapePublisher.cpp
@@ -78,8 +78,8 @@ bool ShapePublisher::initPublisher()
 {
     mp_publisher = mp_sd->getParticipant()->create_publisher(m_pub_qos);
 
-    m_dw_qos.reliable_writer_qos().times.heartbeatPeriod.seconds = 0;
-    m_dw_qos.reliable_writer_qos().times.heartbeatPeriod.nanosec = 500000000;
+    m_dw_qos.reliable_writer_qos().times.heartbeat_period.seconds = 0;
+    m_dw_qos.reliable_writer_qos().times.heartbeat_period.nanosec = 500 * 1000 * 1000;
 
     mp_datawriter = mp_publisher->create_datawriter(mp_topic, m_dw_qos, &listener_);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adapts the code to the RTPS writer APIs refactor. In particular, the rename of `heartbeatPeriod` into `heartbeat_period`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#5028

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- [x] Changes do not break current interoperability.
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
