### PR TITLE
[21321] Update references to `Time_t` and `Duration_t`

### DIFF
--- a/include/eprosimashapesdemo/shapesdemo/ShapeHistory.h
+++ b/include/eprosimashapesdemo/shapesdemo/ShapeHistory.h
@@ -50,7 +50,7 @@ public:
     int32_t m_minX;
     int32_t m_maxY;
     int32_t m_minY;
-    Duration_t m_minimumSeparation;
+    eprosima::fastdds::dds::Duration_t m_minimumSeparation;
     bool m_useContentFilter;
     bool m_useTimeFilter;
 

--- a/include/eprosimashapesdemo/shapesdemo/ShapeInfo.h
+++ b/include/eprosimashapesdemo/shapesdemo/ShapeInfo.h
@@ -68,7 +68,7 @@ public:
 
     ShapeType m_shape;
     TYPESHAPE m_type;
-    Time_t m_time;
+    eprosima::fastdds::dds::Time_t m_time;
     float m_dirX;
     float m_dirY;
     bool m_changeDir;

--- a/src/qt/publishdialog.cpp
+++ b/src/qt/publishdialog.cpp
@@ -127,7 +127,7 @@ void PublishDialog::on_button_OkCancel_accepted()
         if (lease_duration_value.toDouble() > 0)
         {
             SP->m_dw_qos.liveliness().lease_duration =
-                    eprosima::fastdds::Duration_t(lease_duration_value.toDouble() * 1e-3);
+                    eprosima::fastdds::dds::Duration_t(lease_duration_value.toDouble() * 1e-3);
         }
     }
 
@@ -140,14 +140,14 @@ void PublishDialog::on_button_OkCancel_accepted()
             SP->m_dw_qos.liveliness().lease_duration != c_TimeInfinite)
     {
         SP->m_dw_qos.liveliness().announcement_period =
-                eprosima::fastdds::Duration_t(lease_duration_value.toDouble() * 1e-3);
+                eprosima::fastdds::dds::Duration_t(lease_duration_value.toDouble() * 1e-3);
     }
     else
     {
         QString value = this->ui->lineEdit_announcementPeriod->text();
         if (value.toDouble() > 0)
         {
-            SP->m_dw_qos.liveliness().announcement_period = eprosima::fastdds::Duration_t(value.toDouble() * 1e-3);
+            SP->m_dw_qos.liveliness().announcement_period = eprosima::fastdds::dds::Duration_t(value.toDouble() * 1e-3);
         }
     }
 
@@ -196,7 +196,7 @@ void PublishDialog::on_button_OkCancel_accepted()
         QString value = this->ui->lineEdit_Deadline->text();
         if (value.toDouble() > 0)
         {
-            SP->m_dw_qos.deadline().period = eprosima::fastdds::Duration_t(value.toDouble() * 1e-3);
+            SP->m_dw_qos.deadline().period = eprosima::fastdds::dds::Duration_t(value.toDouble() * 1e-3);
         }
     }
 
@@ -210,7 +210,7 @@ void PublishDialog::on_button_OkCancel_accepted()
         QString value = this->ui->lineEdit_Lifespan->text();
         if (value.toDouble() > 0)
         {
-            SP->m_dw_qos.lifespan().duration = eprosima::fastdds::Duration_t(value.toDouble() * 1e-3);
+            SP->m_dw_qos.lifespan().duration = eprosima::fastdds::dds::Duration_t(value.toDouble() * 1e-3);
         }
     }
 

--- a/src/qt/subscribedialog.cpp
+++ b/src/qt/subscribedialog.cpp
@@ -139,7 +139,7 @@ void SubscribeDialog::on_buttonBox_accepted()
         if (value.toDouble() > 0)
         {
             // Liveliness is retrieving by user in ms and is stored in s
-            SSub->m_dr_qos.liveliness().lease_duration = eprosima::fastdds::Duration_t(value.toDouble() * 1e-3);
+            SSub->m_dr_qos.liveliness().lease_duration = eprosima::fastdds::dds::Duration_t(value.toDouble() * 1e-3);
         }
     }
 
@@ -164,7 +164,7 @@ void SubscribeDialog::on_buttonBox_accepted()
         QString value = this->ui->lineEdit_Deadline->text();
         if (value.toDouble() > 0)
         {
-            SSub->m_dr_qos.deadline().period = eprosima::fastdds::Duration_t(value.toDouble() * 1e-3);
+            SSub->m_dr_qos.deadline().period = eprosima::fastdds::dds::Duration_t(value.toDouble() * 1e-3);
         }
     }
 
@@ -178,7 +178,7 @@ void SubscribeDialog::on_buttonBox_accepted()
         QString value = this->ui->lineEdit_Lifespan->text();
         if (value.toDouble() > 0)
         {
-            SSub->m_dr_qos.lifespan().duration = eprosima::fastdds::Duration_t(value.toDouble() * 1e-3);
+            SSub->m_dr_qos.lifespan().duration = eprosima::fastdds::dds::Duration_t(value.toDouble() * 1e-3);
         }
     }
 
@@ -220,7 +220,7 @@ void SubscribeDialog::on_buttonBox_accepted()
             if (value.toInt() > 0)
             {
                 SSub->m_dr_qos.time_based_filter().minimum_separation =
-                        eprosima::fastdds::Duration_t(value.toDouble() * 1e-3);
+                        eprosima::fastdds::dds::Duration_t(value.toDouble() * 1e-3);
             }
 
         }

--- a/src/shapesdemo/ShapeHistory.cpp
+++ b/src/shapesdemo/ShapeHistory.cpp
@@ -57,8 +57,8 @@ inline bool compareGUID(
 }
 
 inline double Time_tAbsDiff2DoubleMillisec(
-        const eprosima::fastdds::Time_t& t1,
-        const eprosima::fastdds::Time_t& t2)
+        const eprosima::fastdds::dds::Time_t& t1,
+        const eprosima::fastdds::dds::Time_t& t2)
 {
     double result = 0;
     result += (double)abs((t2.seconds - t1.seconds) * 1000);
@@ -67,7 +67,7 @@ inline double Time_tAbsDiff2DoubleMillisec(
 }
 
 inline double Time_t2MilliSecondsDouble(
-        const eprosima::fastdds::Time_t& t)
+        const eprosima::fastdds::dds::Time_t& t)
 {
     return ((double)t.fraction() / pow(2.0, 32) * pow(10.0, 3)) + (double)t.seconds * pow(10.0, 3);
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
Related implementation PR:
* eProsima/Fast-DDS#5065

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- __NO__ Changes do not break current interoperability.
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- __NO__ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
