### PR TITLE
[21368] Regenerate types with Fast DDS-Gen v4

### DIFF
--- a/types/KeylessShapeTypeCdrAux.ipp
+++ b/types/KeylessShapeTypeCdrAux.ipp
@@ -139,6 +139,14 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.color();
+
+                        scdr << data.x();
+
+                        scdr << data.y();
+
+                        scdr << data.shapesize();
+
 }
 
 

--- a/types/KeylessShapeTypePubSubTypes.cxx
+++ b/types/KeylessShapeTypePubSubTypes.cxx
@@ -186,7 +186,8 @@ namespace shapes_demo_typesupport {
                     shapes_demo_typesupport_idl_KeylessShapeType_max_key_cdr_typesize);
 
             // Object that serializes the data.
-            eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+            eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+            ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
             eprosima::fastcdr::serialize_key(ser, *p_type);
             if (force_md5 || shapes_demo_typesupport_idl_KeylessShapeType_max_key_cdr_typesize > 16)
             {

--- a/types/KeylessShapeTypePubSubTypes.cxx
+++ b/types/KeylessShapeTypePubSubTypes.cxx
@@ -35,7 +35,7 @@ namespace shapes_demo_typesupport {
     namespace idl {
         KeylessShapeTypePubSubType::KeylessShapeTypePubSubType()
         {
-            set_name("shapes_demo_typesupport::idl::KeylessShapeType");
+            set_name("shapes_demo_typesupport::idl::dds_::KeylessShapeType_");
             uint32_t type_size = shapes_demo_typesupport_idl_KeylessShapeType_max_cdr_typesize;
             type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
             max_serialized_type_size = type_size + 4; /*encapsulation*/

--- a/types/ShapeCdrAux.ipp
+++ b/types/ShapeCdrAux.ipp
@@ -129,9 +129,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ShapeType& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.color();
+                        scdr << data.color();
 
 
 

--- a/types/ShapePubSubTypes.cxx
+++ b/types/ShapePubSubTypes.cxx
@@ -184,7 +184,8 @@ bool ShapeTypePubSubType::compute_key(
             ShapeType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ShapeType_max_key_cdr_typesize > 16)
     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR updates the repo types with the latest changes introduced in the Fast DDS Gen v4.

Interoperability changes is not marked in the checklist as the CDR version has been changed to XCDR2.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- ❌ Changes do not break current interoperability.
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
