### PR TITLE
[21636] Regenerate types with Gen v4.0.1

### DIFF
--- a/types/KeylessShapeTypeCdrAux.hpp
+++ b/types/KeylessShapeTypeCdrAux.hpp
@@ -24,7 +24,7 @@
 
 #include "KeylessShapeType.hpp"
 
-constexpr uint32_t shapes_demo_typesupport_idl_KeylessShapeType_max_cdr_typesize {276UL};
+constexpr uint32_t shapes_demo_typesupport_idl_KeylessShapeType_max_cdr_typesize {272UL};
 constexpr uint32_t shapes_demo_typesupport_idl_KeylessShapeType_max_key_cdr_typesize {0UL};
 
 

--- a/types/KeylessShapeTypeCdrAux.ipp
+++ b/types/KeylessShapeTypeCdrAux.ipp
@@ -47,7 +47,7 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
     size_t calculated_size {calculator.begin_calculate_type_serialized_size(
                                 eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
                                 eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
                                 current_alignment)};
 
@@ -80,7 +80,7 @@ eProsima_user_DllExport void serialize(
     eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
     scdr
@@ -100,7 +100,7 @@ eProsima_user_DllExport void deserialize(
     using namespace shapes_demo_typesupport::idl;
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
             [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {

--- a/types/KeylessShapeTypePubSubTypes.cxx
+++ b/types/KeylessShapeTypePubSubTypes.cxx
@@ -70,7 +70,7 @@ namespace shapes_demo_typesupport {
             ser.set_encoding_flag(
                 data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
                 eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
-                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
 
             try
             {

--- a/types/KeylessShapeTypeTypeObjectSupport.cxx
+++ b/types/KeylessShapeTypeTypeObjectSupport.cxx
@@ -51,7 +51,7 @@ void register_KeylessShapeType_type_identifier(
         "shapes_demo_typesupport::idl::KeylessShapeType", type_ids_KeylessShapeType);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_KeylessShapeType)
     {
-        StructTypeFlag struct_flags_KeylessShapeType = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+        StructTypeFlag struct_flags_KeylessShapeType = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::FINAL,
                 false, false);
         QualifiedTypeName type_name_KeylessShapeType = "shapes_demo_typesupport::idl::KeylessShapeType";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_KeylessShapeType;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR regenerates Shapes Demo project types with the Fast DDS Gen bump version v4.0.1
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- [x] Changes do not break current interoperability.
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
