### PR TITLE
[21560] Regenerate types with Fast-DDS-Gen v3.3.1

### DIFF
--- a/types/KeylessShapeTypePubSubTypes.cxx
+++ b/types/KeylessShapeTypePubSubTypes.cxx
@@ -85,6 +85,11 @@ namespace shapes_demo_typesupport {
                 ser.serialize_encapsulation();
                 // Serialize the object.
                 ser << *p_type;
+        #if FASTCDR_VERSION_MAJOR > 1
+                ser.set_dds_cdr_options({0,0});
+        #else
+                ser.setDDSCdrOptions(0);
+        #endif // FASTCDR_VERSION_MAJOR > 1
             }
             catch (eprosima::fastcdr::exception::Exception& /*exception*/)
             {

--- a/types/ShapePubSubTypes.cxx
+++ b/types/ShapePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool ShapeTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- [x] Changes do not break current interoperability.
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
