### PR TITLE
Remove deprecated windows-2019 runner

### DIFF
--- a/.github/workflows/nightly-windows-ci.yml
+++ b/.github/workflows/nightly-windows-ci.yml
@@ -12,9 +12,10 @@ jobs:
       matrix:
         vs-toolset:
           - 'v142'
+          - 'v143'
     uses: eProsima/ShapesDemo/.github/workflows/reusable-windows-ci.yml@master
     with:
-      os-version: 'windows-2019'
+      os-version: 'windows-2022'
       vs-toolset: ${{ matrix.vs-toolset }}
       label: 'nightly-windows-${{ matrix.vs-toolset }}-ci-master'
       shapes-demo-branch: 'master'
@@ -27,9 +28,10 @@ jobs:
       matrix:
         vs-toolset:
           - 'v142'
+          - 'v143'
     uses: eProsima/ShapesDemo/.github/workflows/reusable-windows-ci.yml@3.2.x
     with:
-      os-version: 'windows-2019'
+      os-version: 'windows-2022'
       vs-toolset: ${{ matrix.vs-toolset }}
       label: 'nightly-windows-${{ matrix.vs-toolset }}-ci-3.2.x'
       shapes-demo-branch: '3.2.x'
@@ -41,14 +43,13 @@ jobs:
       fail-fast: false
       matrix:
         vs-toolset:
-          - 'v141'
           - 'v142'
+          - 'v143'
     uses: eProsima/ShapesDemo/.github/workflows/reusable-windows-ci.yml@2.14.x
     with:
-      os-version: 'windows-2019'
+      os-version: 'windows-2022'
       vs-toolset: ${{ matrix.vs-toolset }}
       label: 'nightly-windows-${{ matrix.vs-toolset }}-ci-2.14.x'
       shapes-demo-branch: '2.14.x'
       fastdds-branch: '2.14.x'
       run-build: true
-

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -6,7 +6,7 @@ on:
       os-version:
         description: 'The OS image for the workflow'
         required: false
-        default: 'windows-2019'
+        default: 'windows-2022'
         type: string
       vs-toolset:
         description: 'The VS toolset to use for the build'

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -6,7 +6,7 @@ on:
       os-version:
         description: 'OS version to run the workflow'
         required: false
-        default: 'windows-2019'
+        default: 'windows-2022'
         type: string
       vs-toolset:
         description: 'The VS toolset to use for the build'
@@ -53,7 +53,7 @@ jobs:
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
-      os-version: ${{ inputs.os-version || 'windows-2019' }}
+      os-version: ${{ inputs.os-version || 'windows-2022' }}
       vs-toolset: ${{ inputs.vs-toolset || 'v142' }}
       label: 'windows-v142-ci-master'
       colcon-args: ${{ inputs.colcon-args }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: 'windows-2022'
         type: string
-      vs-toolset:
-        description: 'The VS toolset to use for the build'
-        required: false
-        default: 'v142'
-        type: string
       colcon-args:
         description: 'Extra arguments for colcon cli'
         required: false
@@ -49,12 +44,18 @@ concurrency:
 jobs:
   windows-ci:
     if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'conflicts') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        vs-toolset:
+          - 'v142'
+          - 'v143'
     uses: ./.github/workflows/reusable-windows-ci.yml
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
       os-version: ${{ inputs.os-version || 'windows-2022' }}
-      vs-toolset: ${{ inputs.vs-toolset || 'v142' }}
+      vs-toolset: ${{ matrix.vs-toolset }}
       label: 'windows-v142-ci-master'
       colcon-args: ${{ inputs.colcon-args }}
       cmake-args: ${{ inputs.cmake-args }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR updates the Windows GitHub Action Runner from `windows-2019` to `windows-2022`. As Visual Studio 2017 build tools (v141) are no longer installed in this new runner, the PR upgrades also to toolsets to use, moving from v141 (VS2017) and v142 (VS2019) to v142 (VS2019) and v143 (VS2022).

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- _N/A_ Changes do not break current interoperability.
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
