### PR TITLE
Invert Y axis checkbox

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -104,7 +104,7 @@ jobs:
         uses: eProsima/eProsima-CI/external/install_qt@v0
         with:
           version: '6.4.2'
-          arch: 'linux_gcc_64'
+          arch: 'gcc_64'
           dir: '/opt/qt_installation/'
           setup-python: 'false'
 

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           version: '6.4.2'
           dir: '/opt/qt_installation/'
-          arch: 'win64_msvc2022_64'
+          arch: 'win64_msvc2019_64'
           setup-python: 'false'
 
       - name: Get Fast DDS branch

--- a/forms/optionsdialog.ui
+++ b/forms/optionsdialog.ui
@@ -86,6 +86,20 @@
      </property>
     </widget>
    </item>
+   <item row="11" column="1">
+    <widget class="QLabel" name="label_invertYAxis">
+     <property name="text">
+      <string>Invert Y axis:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="3">
+    <widget class="QCheckBox" name="checkBox_invertYAxis">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/include/eprosimashapesdemo/qt/optionsdialog.h
+++ b/include/eprosimashapesdemo/qt/optionsdialog.h
@@ -49,6 +49,9 @@ private slots:
     void on_horizontalSlider_speed_valueChanged(
             int arg1);
 
+    void on_checkBox_invertYAxis_stateChanged(
+            int arg1);
+
     void on_pushButton_stop_clicked();
 
 private:

--- a/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
+++ b/include/eprosimashapesdemo/shapesdemo/ShapesDemo.h
@@ -69,6 +69,7 @@ public:
     std::string m_serverIp {"127.0.0.1"};
     uint32_t m_updateIntervalMs {INITIAL_INTERVAL_MS};
     uint32_t m_movementSpeed {7};
+    bool m_invertYAxis {false};
     uint32_t m_domainId {0};
     uint32_t m_lossPerc {1};
     bool m_lossSampleEnabled {false};

--- a/src/qt/DrawArea.cpp
+++ b/src/qt/DrawArea.cpp
@@ -184,26 +184,30 @@ void DrawArea::paintShape(
     m_brush.setStyle(Qt::SolidPattern);
     painter->setPen(m_pen);
     painter->setBrush(m_brush);
+    // Apply the Y axis inversion option, mirroring the shape around the draw area center.
+    int32_t shape_y = mp_SD->m_options.m_invertYAxis
+            ? MAX_DRAW_AREA_Y - shape.m_shape.y()
+            : shape.m_shape.y();
     switch (shape.m_type)
     {
         case SQUARE:
         {
             QRect rect(shape.m_shape.x() - shape.m_shape.shapesize() / 2,
-                    shape.m_shape.y() - shape.m_shape.shapesize() / 2,
+                    shape_y - shape.m_shape.shapesize() / 2,
                     shape.m_shape.shapesize(),
                     shape.m_shape.shapesize());
             painter->drawRect(rect);
             if (shape.dispose)
             {
                 QLine line(shape.m_shape.x() - shape.m_shape.shapesize() / 2,
-                        shape.m_shape.y() - shape.m_shape.shapesize() / 2,
+                        shape_y - shape.m_shape.shapesize() / 2,
                         shape.m_shape.x() + shape.m_shape.shapesize() / 2,
-                        shape.m_shape.y() + shape.m_shape.shapesize() / 2);
+                        shape_y + shape.m_shape.shapesize() / 2);
                 painter->drawLine(line);
                 QLine line2(shape.m_shape.x() + shape.m_shape.shapesize() / 2,
-                        shape.m_shape.y() - shape.m_shape.shapesize() / 2,
+                        shape_y - shape.m_shape.shapesize() / 2,
                         shape.m_shape.x() - shape.m_shape.shapesize() / 2,
-                        shape.m_shape.y() + shape.m_shape.shapesize() / 2);
+                        shape_y + shape.m_shape.shapesize() / 2);
                 painter->drawLine(line2);
             }
             break;
@@ -212,7 +216,7 @@ void DrawArea::paintShape(
         {
             uint32_t x, y, s;
             x = shape.m_shape.x();
-            y = shape.m_shape.y();
+            y = shape_y;
             s = shape.m_shape.shapesize();
             //double h = 0.5*sqrt(3*pow((double)s,2));
             QPoint points[3] = {
@@ -226,7 +230,7 @@ void DrawArea::paintShape(
         case CIRCLE:
         {
             QRect rect(shape.m_shape.x() - shape.m_shape.shapesize() / 2,
-                    shape.m_shape.y() - shape.m_shape.shapesize() / 2,
+                    shape_y - shape.m_shape.shapesize() / 2,
                     shape.m_shape.shapesize(),
                     shape.m_shape.shapesize());
             painter->drawEllipse(rect);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -37,6 +37,7 @@ OptionsDialog::OptionsDialog(
     // Running Congiguration
     this->ui->spin_updateInterval->setValue(m_options.m_updateIntervalMs);
     this->ui->horizontalSlider_speed->setValue(m_options.m_movementSpeed);
+    this->ui->checkBox_invertYAxis->setChecked(m_options.m_invertYAxis);
 
     setAttribute ( Qt::WA_DeleteOnClose, true );
 }
@@ -57,6 +58,13 @@ void OptionsDialog::on_horizontalSlider_speed_valueChanged(
         int arg1)
 {
     m_options.m_movementSpeed = arg1;
+    mp_sd->setOptions(m_options);
+}
+
+void OptionsDialog::on_checkBox_invertYAxis_stateChanged(
+        int arg1)
+{
+    m_options.m_invertYAxis = (arg1 == Qt::Checked);
     mp_sd->setOptions(m_options);
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Adds a checkbox in Options -> Preferences -> Invert Y axis

It allows you to invert the Y axis, so that it increments from bottom to top.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- [x] Changes do not break current interoperability.
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
