### PR TITLE
[#25465] Support multi-select endpoint deletion and fixed a typo

### DIFF
--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -253,7 +253,7 @@
            <set>QAbstractItemView::NoEditTriggers</set>
           </property>
           <property name="selectionMode">
-           <enum>QAbstractItemView::SingleSelection</enum>
+           <enum>QAbstractItemView::ExtendedSelection</enum>
           </property>
           <property name="selectionBehavior">
            <enum>QAbstractItemView::SelectRows</enum>
@@ -355,7 +355,7 @@
   </action>
   <action name="actionDelete_Enpoint">
    <property name="text">
-    <string>Delete Enpoint</string>
+    <string>Delete Endpoint</string>
    </property>
   </action>
   <action name="actionAbout">

--- a/include/eprosimashapesdemo/qt/mainwindow.h
+++ b/include/eprosimashapesdemo/qt/mainwindow.h
@@ -124,9 +124,6 @@ private slots:
 
     void on_actionDelete_Enpoint_triggered();
 
-    void on_tableEndpoint_clicked(
-            const QModelIndex& index);
-
     void on_MainWindow_destroyed();
 
     void closeEvent(
@@ -152,8 +149,9 @@ private:
     UpdateThread* mp_writeThread;
     QStandardItemModel* m_pubsub;
     std::vector<SD_Endpoint> m_pubsub_pointers;
-    int m_tableRow;
     AxisArrowOverlay* m_axisOverlay;
+    std::vector<int> selectedEndpointRows() const;
+    void removeSelectedRows();
     void removeRow(
             int row);
 };

--- a/src/qt/mainwindow.cpp
+++ b/src/qt/mainwindow.cpp
@@ -35,6 +35,7 @@
 #include <QDir>
 #include <QProcess>
 
+#include <algorithm>
 #include <iostream>
 
 
@@ -44,7 +45,6 @@ MainWindow::MainWindow(
     , ui(new Ui::MainWindow)
     , m_shapesDemo(this)
     , mp_writeThread(NULL)
-    , m_tableRow(-1)
 {
     setWindowIcon(QIcon(":images/eprosima_icon.png"));
 
@@ -192,6 +192,7 @@ void MainWindow::on_actionStop_triggered()
 {
     this->m_shapesDemo.stop();
     m_pubsub->removeRows(0, m_pubsub->rowCount());
+    m_pubsub_pointers.clear();
     update();
     addMessageToOutput(QString("ShapesDemo stopped"), true);
 }
@@ -390,13 +391,18 @@ void MainWindow::addSubscriberToTable(
 void MainWindow::on_tableEndpoint_customContextMenuRequested(
         const QPoint& pos)
 {
-    // cout <<"CONTEXT MENU REQUESTED"<<endl;
     QModelIndex index = this->ui->tableEndpoint->indexAt(pos);
-    this->ui->tableEndpoint->selectRow(index.row());
-    // cout << index.column()<< " "<< index.row()<<endl;
-    this->m_tableRow = index.row();
     if (index.row() >= 0)
     {
+        QItemSelectionModel* selection_model = this->ui->tableEndpoint->selectionModel();
+        if (selection_model != nullptr &&
+                !selection_model->isRowSelected(index.row(), QModelIndex()))
+        {
+            selection_model->select(
+                index,
+                QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+        }
+
         QMenu* menu = new QMenu(this);
         menu->addAction(this->ui->actionDelete_Enpoint);
         menu->popup(this->ui->tableEndpoint->viewport()->mapToGlobal(pos));
@@ -405,49 +411,87 @@ void MainWindow::on_tableEndpoint_customContextMenuRequested(
 
 void MainWindow::on_actionDelete_Enpoint_triggered()
 {
-    //cout << "DELETE ENDPOINT" <<endl;
-    removeRow(m_tableRow);
+    removeSelectedRows();
+}
+
+std::vector<int> MainWindow::selectedEndpointRows() const
+{
+    std::vector<int> rows;
+    QItemSelectionModel* selection_model = this->ui->tableEndpoint->selectionModel();
+
+    if (selection_model == nullptr)
+    {
+        return rows;
+    }
+
+    QModelIndexList selected_rows = selection_model->selectedRows();
+    rows.reserve(selected_rows.size());
+
+    for (const QModelIndex& index : selected_rows)
+    {
+        rows.push_back(index.row());
+    }
+
+    std::sort(rows.begin(), rows.end(), [](int lhs, int rhs)
+            {
+                return lhs > rhs;
+            });
+    rows.erase(std::unique(rows.begin(), rows.end()), rows.end());
+
+    return rows;
+}
+
+void MainWindow::removeSelectedRows()
+{
+    for (int row : selectedEndpointRows())
+    {
+        removeRow(row);
+    }
 }
 
 void MainWindow::removeRow(
         int row)
 {
     //  cout << "REMOVING ROW **************************"<<endl;
-    m_pubsub->removeRow(row);
-    for (std::vector<SD_Endpoint>::iterator it = this->m_pubsub_pointers.begin();
-            it != this->m_pubsub_pointers.end(); ++it)
+    if (row < 0 || row >= m_pubsub->rowCount())
     {
-        if (row == it->pos)
-        {
-            if (it->type == PUB)
-            {
-                // cout << "REMOVING PUBLISHER "<<endl;
-                this->m_shapesDemo.removePublisher(it->pub);
-                addMessageToOutput(QString("Removed Publisher"), false);
-            }
-            else
-            {
-                //   cout << "REMOVING SUBSCRIBER "<<endl;
-                this->m_shapesDemo.removeSubscriber(it->sub);
-                addMessageToOutput(QString("Removed Subscriber"), false);
-            }
-
-            for (std::vector<SD_Endpoint>::iterator it2 = it; it2 != this->m_pubsub_pointers.end(); ++it2)
-            {
-                it2->pos--;
-                //  cout << "POSITION -1"<<endl;
-            }
-            m_pubsub_pointers.erase(it);
-            break;
-        }
+        return;
     }
-    //cout << "FINISH REMOVE ROW"<<endl;
-}
 
-void MainWindow::on_tableEndpoint_clicked(
-        const QModelIndex& index)
-{
-    this->ui->tableEndpoint->selectRow(index.row());
+    std::vector<SD_Endpoint>::iterator endpoint_it = std::find_if(
+        m_pubsub_pointers.begin(),
+        m_pubsub_pointers.end(),
+        [row](const SD_Endpoint& endpoint)
+        {
+            return endpoint.pos == row;
+        });
+
+    if (endpoint_it == m_pubsub_pointers.end())
+    {
+        return;
+    }
+
+    m_pubsub->removeRow(row);
+
+    if (endpoint_it->type == PUB)
+    {
+        this->m_shapesDemo.removePublisher(endpoint_it->pub);
+        addMessageToOutput(QString("Removed Publisher"), false);
+    }
+    else
+    {
+        this->m_shapesDemo.removeSubscriber(endpoint_it->sub);
+        addMessageToOutput(QString("Removed Subscriber"), false);
+    }
+
+    for (std::vector<SD_Endpoint>::iterator it = endpoint_it + 1;
+            it != this->m_pubsub_pointers.end(); it++)
+    {
+        it->pos--;
+    }
+
+    m_pubsub_pointers.erase(endpoint_it);
+    //cout << "FINISH REMOVE ROW"<<endl;
 }
 
 void MainWindow::keyPressEvent(
@@ -455,17 +499,11 @@ void MainWindow::keyPressEvent(
 {
     if (event->key() == Qt::Key_Delete)
     {
-        QItemSelectionModel* select = this->ui->tableEndpoint->selectionModel();
-        if (select->hasSelection())
-        {
-            QModelIndexList list = select->selectedRows();
-            for (QModelIndexList::iterator it = list.begin(); it != list.end(); ++it)
-            {
-                removeRow(it->row());
-            }
-
-        }
+        removeSelectedRows();
+        return;
     }
+
+    QMainWindow::keyPressEvent(event);
 }
 
 void MainWindow::on_actionAbout_triggered()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR improves endpoint management in the Qt UI by allowing multiple endpoints to be selected and removed in one action.

It also fixes the `Delete Enpoint` typo in the context menu label.

### Local steps to test it

1. Single-click selects one endpoint row
2. Press keyboard key "Ctrl"/"Shift"
2.1 **`Ctrl`** + click adds or removes individual rows from the selection
2.2 **`Shift`** + click selects a contiguous row range 
2.3 **`Shift`** + _<up/down>_ adds or removes individual adjacent row from the selection
3. Deletion
3.1 Pressing `Delete` removes all selected endpoints
3.2 Right-clicking a selected row keeps the current multi-selection

### Documentation [PR](https://github.com/eProsima/Shapes-Demo-Docs/pull/210)

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->
@Mergifyio backport 3.2.x 2.14.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo developers must also refer to the internal Redmine task. -->
- [x] Changes do not break current interoperability.
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- Related documentation PR: eProsima/Shapes-Demo-Docs# (PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
